### PR TITLE
Include more details on main definition format

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ To use Lapis, first download the example deck from [Releases](https://github.com
 | ExpressionReading  | `{reading}`                                        |
 | ExpressionAudio    | `{audio}`                                          |
 | SelectionText      | `{popup-selection-text}`                           |
-| MainDefinition     | Something like `{single-glossary-jmdict/jitendex}` |
+| MainDefinition     | Something like `{single-glossary-jmdict/jitendex}`. Find this by clicking the down arrow next to this field, and finding a dictionary in a similar format. |
 | Sentence           | `{cloze-prefix}<b>{cloze-body}</b>{cloze-suffix}`  |
 | SentenceFurigana   |                                                    |
 | SentenceAudio      |                                                    |


### PR DESCRIPTION
**Problem**

I know absolutely nothing about dictionaries and I don't want to know. I just want to import something and have it work first time.

The current docs suggest copying and pasting these lines, but this line I changed cannot be copied and pasted because its dictionary specific.

**Solution**

I spent 15 minutes debugging this and wrote this extra line that suggests how a user, like me, can find the right thing to use here.

This should hopefully make it easier for people like me in the future to use this 😇 