### PR TITLE
Add tappable to image

### DIFF
--- a/src/back.html
+++ b/src/back.html
@@ -51,7 +51,7 @@
       <!-- Image -->
       <div class="dh-right">
         {{#Picture}}
-          <div class="image {{Tags}}">{{Picture}}</div>
+          <div class="image tappable {{Tags}}">{{Picture}}</div>
         {{/Picture}}
       </div>
     </div>
@@ -77,7 +77,7 @@
   </div>
 
   <!------- Image modal --------->
-  <div class="modal-bg"></div>
+  <div class="modal-bg tappable"></div>
   <div class="img-popup"></div>
 
   {{#MiscInfo}}


### PR DESCRIPTION
Add the tappable class so that iOS gesture handling doesn't eat the taps to zoom and dismiss the picture.