### PR TITLE
Change toggle definition logic

### DIFF
--- a/src/back.html
+++ b/src/back.html
@@ -63,15 +63,19 @@
             {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
         </div>
 
-  <!-- The entire definition blockquote -->
-  <div class="def-info-container"><div class="def-info"></div></div>
-    <blockquote class="main-def def-blockquote">
-      <div class="definition">
-        {{#SelectionText}}<div id="selection" data-display-name="Text Selection">{{SelectionText}}</div>{{/SelectionText}}
-        {{#MainDefinition}}<div id="primary" data-display-name="Primary Definition">{{MainDefinition}}</div>{{/MainDefinition}}
-        <div id="glossaries" data-display-name="Glossaries">{{Glossary}}</div>
-      </div>
-    </blockquote>
+        <!-- The entire definition blockquote -->
+        <div class="def-info-container"><div class="def-info"></div></div>
+        <blockquote class="main-def def-blockquote">
+            <div class="definition">
+                {{#SelectionText}}
+                <div id="selection" data-display-name="Text Selection">{{SelectionText}}</div>
+                {{/SelectionText}}
+                {{#MainDefinition}}
+                <div id="primary" data-display-name="Primary Definition">{{MainDefinition}}</div>
+                {{/MainDefinition}}
+                <div id="glossaries" data-display-name="Glossaries">{{Glossary}}</div>
+            </div>
+        </blockquote>
 
         <!-- This is for the sentence that you see on mobile (positioned under definition), on Desktop, the sentence goes above the definition box, and this is hidden -->
         <div class="sentence-mobile">
@@ -326,170 +330,171 @@
         pitchTags.appendChild(pitchTagList);
     }
 
-  // Helper function to check if a field is just html without any content
-  function isAllHtml(content) {
-    const strippedContent = content.replace(/<\/?[^>]+(>|$)/g, "").trim();
-    return strippedContent === "" && content.match(/<\/?[^>]+(>|$)/g) !== null;
-  }
-
-
-  function isPrimaryEqualToGloss() {
-      const isJPMNConverted = document.querySelector(".definition li[data-details]");
-      if (isJPMNConverted) return false;
-      // single dict formatting
-      const isSingleDict = document.querySelectorAll("#glossaries > div > ol").length === 0;
-      if (isSingleDict) {
-          const primaryDictName = document.querySelector("#primary > div > i");
-          const glossariesDictName = document.querySelector("#glossaries > div > i");
-          // {glossary-brief} and {glossary-no-dictionary} formatting
-          if (!primaryDictName || !glossariesDictName) {
-              const primaryDict = document.querySelector("#primary > div > span");
-              const glossariesDict = document.querySelector("#glossaries > div > span");
-              return primaryDict.innerHTML === glossariesDict.innerHTML
-          }
-          return primaryDictName.textContent === glossariesDictName.textContent;
-      }
-
-      // multiple dicts
-      const primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
-      const glossariesDicts = document.querySelectorAll("#glossaries li[data-dictionary]");
-      return primaryDicts.length === glossariesDicts.length
-      /*
-      const primaryDictsNames = Array.from(primaryDicts).map( li => li.getAttribute("data-dictionary") );
-      const glossariesDictsNames = Array.from(glossariesDicts).map( li => li.getAttribute("data-dictionary") );
-      return glossariesDictsNames.every( li => primaryDictsNames.includes(li) ); 
-      */
-  }
-
-  // Removes Unnecessary definitions
-  function cleanUpDefinitions() {
-      const primary = document.getElementById("primary");
-      const glossaries = document.getElementById("glossaries");
-      if (primary && primary.textContent === "" ) {
-          console.log("primary empty");
-          primary.remove()
-      }
-      if (glossaries && glossaries.textContent === "") {
-          console.log("gloss empty");
-          glossaries.remove()
-      }
-      else if (primary && glossaries && isPrimaryEqualToGloss()) {
-          console.log("gloss = primary");
-          glossaries.remove()
-      }
-  }
-
-  function updateDefDisplay() {
-      const definitions = document.querySelectorAll(
-        ".main-def > .definition > div"
-      );
-
-      let n_defs = definitions.length;
-      if (n_defs === 1) definitions[0].classList.remove("hidden");
-      if (n_defs <= 1) return;
-
-      let currentIndex = document.head.getAttribute("data-def-index");
-      currentIndex = currentIndex % n_defs;
-      while (currentIndex < 0) currentIndex += n_defs;
-
-      for (let idx = 0; idx < n_defs; idx++) {
-          definitions[idx].classList.add("hidden");
-      }
-      definitions[currentIndex].classList.remove("hidden");
-
-      const defDisplayName = definitions[currentIndex].getAttribute("data-display-name")
-      const indexDisplay = document.querySelector(".def-info");
-      indexDisplay.style.opacity = 1;
-      indexDisplay.innerText = `${defDisplayName} ${currentIndex + 1}/${n_defs}`;
-  }
-
-  function setUpDefToggle() {
-    document.head.setAttribute("data-def-index", 0);
-    cleanUpDefinitions();
-
-    // hide all but first definition
-    let definitions = document.querySelectorAll(".main-def > .definition > div");
-    Array.from(definitions).slice(1).forEach( def => { def.classList.add("hidden"); });
-    // no need for toggling on less than 2 definitions
-    if (definitions.length < 2) return;
-
-    let mainDefContainer = document.querySelector(".main-def");
-
-    const leftEdge = document.createElement("div");
-    const rightEdge = document.createElement("div");
-    leftEdge.classList.add("left-edge");
-    leftEdge.classList.add("tappable");
-    rightEdge.classList.add("right-edge");
-    rightEdge.classList.add("tappable");
-    mainDefContainer.appendChild(leftEdge);
-    mainDefContainer.appendChild(rightEdge);
-
-    const changeIndex = (value) => {
-      // sync index between clicks and arrowkeys
-      index = Number(document.head.getAttribute("data-def-index"));
-      index += value;
-      document.head.setAttribute("data-def-index", index);
-      updateDefDisplay();
-    };
-
-    leftEdge.addEventListener("click", (e) => changeIndex(-1));
-    rightEdge.addEventListener("click", (e) => changeIndex(1));
-
-    // Add key listener only once per session
-    if (document.head.classList.contains("has-listener")) return;
-    document.addEventListener("keydown", (e) => {
-      if (e.key === "ArrowLeft") changeIndex(-1);
-      else if (e.key === "ArrowRight") changeIndex(1);
-    });
-
-    document.head.classList.add("has-listener");
-  }
-
-  // By default, it's going to be SelectionText in that field, but what if it is empty i.e user has not selected any text?
-  function showCorrectDef() {
-    const selectionText = document.querySelector(".main-def > .definition");
-    if ((selectionText.innerHTML.trim() == "" && `{{MainDefinition}}`) && isAllHtml(`{{MainDefinition}}`) == false) {
-      selectionText.innerHTML = `<div id="primary">{{MainDefinition}}</div>`;
+    // Helper function to check if a field is just html without any content
+    function isAllHtml(content) {
+        const strippedContent = content.replace(/<\/?[^>]+(>|$)/g, "").trim();
+        return strippedContent === "" && content.match(/<\/?[^>]+(>|$)/g) !== null;
     }
-    else if (selectionText.innerHTML.trim() == "" && (`{{MainDefinition}}` == "" || isAllHtml(`{{MainDefinition}}`) == true))
-      selectionText.innerHTML = `<div id="glossaries">{{Glossary}}</div>`;
-  }
+
+
+    function isPrimaryEqualToGloss() {
+        const isJPMNConverted = document.querySelector(".definition li[data-details]");
+        if (isJPMNConverted) return false;
+        // single dict formatting
+        const isSingleDict = document.querySelectorAll("#glossaries > div > ol").length === 0;
+        if (isSingleDict) {
+            const primaryDictName = document.querySelector("#primary > div > i");
+            const glossariesDictName = document.querySelector("#glossaries > div > i");
+            // {glossary-brief} and {glossary-no-dictionary} formatting
+            if (!primaryDictName || !glossariesDictName) {
+                const primaryDict = document.querySelector("#primary > div > span");
+                const glossariesDict = document.querySelector("#glossaries > div > span");
+                return primaryDict.innerHTML === glossariesDict.innerHTML
+            }
+            return primaryDictName.textContent === glossariesDictName.textContent;
+        }
+
+        // multiple dicts
+        const primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
+        const glossariesDicts = document.querySelectorAll("#glossaries li[data-dictionary]");
+        return primaryDicts.length === glossariesDicts.length
+        /*
+        const primaryDictsNames = Array.from(primaryDicts).map( li => li.getAttribute("data-dictionary") );
+        const glossariesDictsNames = Array.from(glossariesDicts).map( li => li.getAttribute("data-dictionary") );
+        return glossariesDictsNames.every( li => primaryDictsNames.includes(li) ); 
+        */
+    }
+
+    // Removes Unnecessary definitions
+    function cleanUpDefinitions() {
+        const primary = document.getElementById("primary");
+        const glossaries = document.getElementById("glossaries");
+        if (primary && primary.textContent === "" ) {
+            console.log("primary empty");
+            primary.remove()
+        }
+        if (glossaries && glossaries.textContent === "") {
+            console.log("gloss empty");
+            glossaries.remove()
+        }
+        else if (primary && glossaries && isPrimaryEqualToGloss()) {
+            console.log("gloss = primary");
+            glossaries.remove()
+        }
+    }
+
+    // Display definition corresponding to index
+    function updateDefDisplay() {
+        const definitions = document.querySelectorAll(
+            ".main-def > .definition > div"
+        );
+
+        let n_defs = definitions.length;
+        if (n_defs === 1) definitions[0].classList.remove("hidden");
+        if (n_defs <= 1) return;
+
+        let currentIndex = document.head.getAttribute("data-def-index");
+        currentIndex = currentIndex % n_defs;
+        while (currentIndex < 0) currentIndex += n_defs;
+
+        for (let idx = 0; idx < n_defs; idx++) {
+            definitions[idx].classList.add("hidden");
+        }
+        definitions[currentIndex].classList.remove("hidden");
+
+        const defDisplayName = definitions[currentIndex].getAttribute("data-display-name")
+        const indexDisplay = document.querySelector(".def-info");
+        indexDisplay.style.opacity = 1;
+        indexDisplay.innerText = `${defDisplayName} ${currentIndex + 1}/${n_defs}`;
+    }
+
+    function setUpDefToggle() {
+        document.head.setAttribute("data-def-index", 0);
+        cleanUpDefinitions();
+
+        // hide all but first definition
+        let definitions = document.querySelectorAll(".main-def > .definition > div");
+        Array.from(definitions).slice(1).forEach( def => { def.classList.add("hidden"); });
+        // no need for toggling on less than 2 definitions
+        if (definitions.length < 2) return;
+
+        let mainDefContainer = document.querySelector(".main-def");
+
+        const leftEdge = document.createElement("div");
+        const rightEdge = document.createElement("div");
+        leftEdge.classList.add("left-edge");
+        leftEdge.classList.add("tappable");
+        rightEdge.classList.add("right-edge");
+        rightEdge.classList.add("tappable");
+        mainDefContainer.appendChild(leftEdge);
+        mainDefContainer.appendChild(rightEdge);
+
+        const changeIndex = (value) => {
+            // sync index between clicks and arrowkeys
+            index = Number(document.head.getAttribute("data-def-index"));
+            index += value;
+            document.head.setAttribute("data-def-index", index);
+            updateDefDisplay();
+        };
+
+        leftEdge.addEventListener("click", (e) => changeIndex(-1));
+        rightEdge.addEventListener("click", (e) => changeIndex(1));
+
+        // Add key listener only once per session
+        if (document.head.classList.contains("has-listener")) return;
+        document.addEventListener("keydown", (e) => {
+            if (e.key === "ArrowLeft") changeIndex(-1);
+            else if (e.key === "ArrowRight") changeIndex(1);
+        });
+
+        document.head.classList.add("has-listener");
+    }
+
+    // By default, it's going to be SelectionText in that field, but what if it is empty i.e user has not selected any text?
+    function showCorrectDef() {
+        const selectionText = document.querySelector(".main-def > .definition");
+        if ((selectionText.innerHTML.trim() == "" && `{{MainDefinition}}`) && isAllHtml(`{{MainDefinition}}`) == false) {
+            selectionText.innerHTML = `<div id="primary">{{MainDefinition}}</div>`;
+        }
+        else if (selectionText.innerHTML.trim() == "" && (`{{MainDefinition}}` == "" || isAllHtml(`{{MainDefinition}}`) == true))
+            selectionText.innerHTML = `<div id="glossaries">{{Glossary}}</div>`;
+    }
 
   // This just handles clicking and showing images
-  function clickImage() {
-    const modalBg = document.querySelector(".modal-bg");
-    const imgPopup = document.querySelector(".img-popup");
-    const image = document.querySelector(".image img");
+    function clickImage() {
+        const modalBg = document.querySelector(".modal-bg");
+        const imgPopup = document.querySelector(".img-popup");
+        const image = document.querySelector(".image img");
 
-    if (!image) return;
+        if (!image) return;
 
-    image.addEventListener("click", () => {
-        const imgPopupContainer = document.createElement("div");
-        const imgPopupImg = document.createElement("img");
+        image.addEventListener("click", () => {
+            const imgPopupContainer = document.createElement("div");
+            const imgPopupImg = document.createElement("img");
 
-        imgPopupContainer.classList.add("img-popup-container");
-        imgPopupImg.src = image.src;
-        imgPopupImg.classList.add("img-popup-img");
+            imgPopupContainer.classList.add("img-popup-container");
+            imgPopupImg.src = image.src;
+            imgPopupImg.classList.add("img-popup-img");
 
-        if (image.height > image.width) {
-            imgPopupContainer.style.height = "calc(100% - 20px)";
-            imgPopupContainer.style.width = "max-content";
-        }
-        imgPopup.innerHTML = "";
-        imgPopup.appendChild(imgPopupContainer);
-        imgPopupContainer.appendChild(imgPopupImg);
+            if (image.height > image.width) {
+                imgPopupContainer.style.height = "calc(100% - 20px)";
+                imgPopupContainer.style.width = "max-content";
+            }
+            imgPopup.innerHTML = "";
+            imgPopup.appendChild(imgPopupContainer);
+            imgPopupContainer.appendChild(imgPopupImg);
 
-        document.body.classList.add("img-popup");
-        modalBg.style.display = "block";
-        imgPopupContainer.style.display = "flex";
-    });
+            document.body.classList.add("img-popup");
+            modalBg.style.display = "block";
+            imgPopupContainer.style.display = "flex";
+        });
 
-    modalBg.addEventListener("click", () => {
-        document.body.classList.remove("img-popup");
-        modalBg.style.display = "none";
-        imgPopup.innerHTML = "";
-    });
-  }
+        modalBg.addEventListener("click", () => {
+            document.body.classList.remove("img-popup");
+            modalBg.style.display = "none";
+            imgPopup.innerHTML = "";
+        });
+    }
 
     // Handles what you see when you hover over frequency dropdown icon
     function frequencyHover() {
@@ -522,49 +527,49 @@
         }
     }
 
-  // Hides the dictionary user selected in MainDefinition in Glossary field, if any
-  function hideCorrectDefinition() {
-    // Do nothing if css rule already exists
-    if (document.querySelector("blockquote.main-def style")) return;
+    // Hides the dictionaries user selected in MainDefinition in Glossary field, if any
+    function hideCorrectDefinition() {
+        // Do nothing if css rule already exists
+        if (document.querySelector("blockquote.main-def style")) return;
 
-    let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
-    if (primaryDicts.length === 0) return;
+        let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
+        if (primaryDicts.length === 0) return;
 
-        let style = document.createElement('style');
-        style.type = 'text/css';
+            let style = document.createElement('style');
+            style.type = 'text/css';
 
-        const cssSelector = Array.from(primaryDicts).map((dict) =>
-            `#glossaries li[data-dictionary="${dict.getAttribute("data-dictionary")}"]`
-        ).join(", ");
-        const cssRules = `${cssSelector} { display:none !important; }`;
-        style.appendChild(document.createTextNode(cssRules));
+            const cssSelector = Array.from(primaryDicts).map((dict) =>
+                `#glossaries li[data-dictionary="${dict.getAttribute("data-dictionary")}"]`
+            ).join(", ");
+            const cssRules = `${cssSelector} { display:none !important; }`;
+            style.appendChild(document.createTextNode(cssRules));
 
-        let defContainer = document.querySelector("blockquote.main-def");
-        defContainer.appendChild(style);
+            let defContainer = document.querySelector("blockquote.main-def");
+            defContainer.appendChild(style);
     }
 
-  // Moves Primary Dicts into the same list
-  function movePrimaryDicts() {
-    let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
-    let firstList = document.querySelector("#primary .yomitan-glossary > ol:has( li[data-dictionary])");
-    for (let idx = 1; idx < primaryDicts.length; idx++) {
-        firstList.appendChild(primaryDicts[idx]);
+    // Moves Primary Dicts into the same list
+    function movePrimaryDicts() {
+        let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
+        let firstList = document.querySelector("#primary .yomitan-glossary > ol:has( li[data-dictionary])");
+        for (let idx = 1; idx < primaryDicts.length; idx++) {
+            firstList.appendChild(primaryDicts[idx]);
+        }
     }
-  }
 
-  // Initialize all functions!!!
-  function initialize() {
-    tweakHTML();
-    paintTargetWord();
-    constructPitch();
-    setUpDefToggle();
-    //showCorrectDef();
-    clickImage();
-    frequencyHover();
-    setDHHeight();
-    hideCorrectDefinition();
-    movePrimaryDicts();
-  }
+    // Initialize all functions!!!
+    function initialize() {
+        tweakHTML();
+        paintTargetWord();
+        constructPitch();
+        setUpDefToggle();
+        //showCorrectDef();
+        clickImage();
+        frequencyHover();
+        setDHHeight();
+        hideCorrectDefinition();
+        movePrimaryDicts();
+    }
 
     initialize();
 </script>

--- a/src/back.html
+++ b/src/back.html
@@ -341,7 +341,7 @@
       if (isSingleDict) {
           const primaryDictName = document.querySelector("#primary > div > i");
           const glossariesDictName = document.querySelector("#glossaries > div > i");
-          return primaryDictName.innerText === glossariesDictName.innerText;
+          return primaryDictName.textContent === glossariesDictName.textContent;
       }
 
       // multiple dicts
@@ -361,21 +361,21 @@
       const glossaries = document.getElementById("glossaries");
       if (primary && primary.textContent === "" ) {
           console.log("primary empty");
-          primary.classList.add("empty");
+          primary.remove()
       }
       if (glossaries && glossaries.textContent === "") {
           console.log("gloss empty");
-          glossaries.classList.add("empty");
+          glossaries.remove()
       }
       else if (primary && glossaries && isPrimaryEqualToGloss()) {
           console.log("gloss = primary");
-          glossaries.classList.add("empty");
+          glossaries.remove()
       }
   }
 
   function updateDefDisplay() {
       const definitions = document.querySelectorAll(
-        ".main-def > .definition > div:not(.empty)"
+        ".main-def > .definition > div"
       );
 
       let n_defs = definitions.length;
@@ -401,13 +401,12 @@
 
   function setUpDefToggle() {
     document.head.setAttribute("data-def-index", 0);
-
     cleanUpDefinitions();
 
-    // hide all but first def
-    let definitions = document.querySelectorAll(".main-def > .definition > div:not(.empty)");
+    // hide all but first definition
+    let definitions = document.querySelectorAll(".main-def > .definition > div");
     Array.from(definitions).slice(1).forEach( def => { def.classList.add("hidden"); });
-    // nothing if no more than 1 def
+    // no need for toggling on less than 2 definitions
     if (definitions.length < 2) return;
 
     let mainDefContainer = document.querySelector(".main-def");
@@ -422,7 +421,7 @@
     mainDefContainer.appendChild(rightEdge);
 
     const changeIndex = (value) => {
-      // sync index
+      // sync index between clicks and arrowkeys
       index = Number(document.head.getAttribute("data-def-index"));
       index += value;
       document.head.setAttribute("data-def-index", index);
@@ -432,7 +431,7 @@
     leftEdge.addEventListener("click", (e) => changeIndex(-1));
     rightEdge.addEventListener("click", (e) => changeIndex(1));
 
-    // Add key listener only once at session start
+    // Add key listener only once per session
     if (document.head.classList.contains("has-listener")) return;
     document.addEventListener("keydown", (e) => {
       if (e.key === "ArrowLeft") changeIndex(-1);

--- a/src/back.html
+++ b/src/back.html
@@ -332,52 +332,57 @@
     return strippedContent === "" && content.match(/<\/?[^>]+(>|$)/g) !== null;
   }
 
-  
-  function isPrimaryAndGlossEqual() {
-    const isJPMNConverted = document.querySelector("li[data-details]") !== null;
-    if (isJPMNConverted) return false;
-    // single dict formatting
-    const isSingleDict = document.querySelectorAll("#glossaries > div > ol").length === 0;
-    if (isSingleDict) {
-      const primary = document.querySelector("#primary > div:has(i)");
-      const glossaries = document.querySelector("#glossaries > div:has(i)");
-      return primary.innerHTML === glossaries.innerHTML;
-    }
- 
-    // multiple dicts
-    const primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
-    const primaryDictsNames = Array.from(primaryDicts).map( li => li.getAttribute("data-dictionary") );
-    const glossariesDicts = document.querySelectorAll("#glossaries li[data-dictionary]");
-    const glossariesDictsNames = Array.from(glossariesDicts).map( li => li.getAttribute("data-dictionary") );
-    return glossariesDictsNames.every( li => primaryDictsNames.includes(li) );
+
+  function isPrimaryEqualToGloss() {
+      const isJPMNConverted = document.querySelector("li[data-details]");
+      if (isJPMNConverted) return false;
+      // single dict formatting
+      const isSingleDict = document.querySelectorAll("#glossaries > div > ol").length === 0;
+      if (isSingleDict) {
+          const primaryDictName = document.querySelector("#primary > div > i");
+          const glossariesDictName = document.querySelector("#glossaries > div > i");
+          return primaryDictName.innerText === glossariesDictName.innerText;
+      }
+
+      // multiple dicts
+      const primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
+      const glossariesDicts = document.querySelectorAll("#glossaries li[data-dictionary]");
+      return primaryDicts.length === glossariesDicts.length
+      /*
+      const primaryDictsNames = Array.from(primaryDicts).map( li => li.getAttribute("data-dictionary") );
+      const glossariesDictsNames = Array.from(glossariesDicts).map( li => li.getAttribute("data-dictionary") );
+      return glossariesDictsNames.every( li => primaryDictsNames.includes(li) ); 
+      */
   }
 
   // Removes Unnecessary definitions
-  function cleanDefinitions() {
+  function cleanUpDefinitions() {
       const primary = document.getElementById("primary");
       const glossaries = document.getElementById("glossaries");
-      if (primary && primary.innerText.trim() === "") {
-          primary.remove();
+      if (primary && primary.textContent === "" ) {
+          console.log("primary empty");
+          primary.classList.add("empty");
       }
-      if (glossaries && glossaries.innerText.trim() === "") {
-          glossaries.remove();
+      if (glossaries && glossaries.textContent === "") {
+          console.log("gloss empty");
+          glossaries.classList.add("empty");
       }
-      else if (primary && glossaries && isPrimaryAndGlossEqual()) {
-          glossaries.remove();
+      else if (primary && glossaries && isPrimaryEqualToGloss()) {
+          console.log("gloss = primary");
+          glossaries.classList.add("empty");
       }
   }
 
   function updateDefDisplay() {
       const definitions = document.querySelectorAll(
-        ".main-def > .definition > div"
+        ".main-def > .definition > div:not(.empty)"
       );
 
       let n_defs = definitions.length;
       if (n_defs === 1) {
         definitions[0].classList.remove("hidden");
-        return;
       }
-      else if (n_defs < 1) return;
+      else if (n_defs <= 1) return;
 
       let currentIndex = document.head.getAttribute("data-def-index");
       currentIndex = currentIndex % n_defs;
@@ -388,23 +393,20 @@
       }
       definitions[currentIndex].classList.remove("hidden");
 
+      const defDisplayName = definitions[currentIndex].getAttribute("data-display-name")
       const indexDisplay = document.querySelector(".def-info");
       indexDisplay.style.opacity = 1;
-      indexDisplay.innerText = `${definitions[currentIndex].getAttribute("data-display-name")} \
-          ${currentIndex + 1}/${n_defs}
-      `;
+      indexDisplay.innerText = `${defDisplayName} ${currentIndex + 1}/${n_defs}`;
   }
 
   function setUpDefToggle() {
     document.head.setAttribute("data-def-index", 0);
 
-    cleanDefinitions();
+    cleanUpDefinitions();
 
     // hide all but first def
-    let definitions = document.querySelectorAll(".main-def > .definition > div");
-    Array.from(definitions).slice(1).forEach( def => {
-        def.classList.add("hidden");
-    });
+    let definitions = document.querySelectorAll(".main-def > .definition > div:not(.empty)");
+    Array.from(definitions).slice(1).forEach( def => { def.classList.add("hidden"); });
     // nothing if no more than 1 def
     if (definitions.length < 2) return;
 

--- a/src/back.html
+++ b/src/back.html
@@ -379,10 +379,8 @@
       );
 
       let n_defs = definitions.length;
-      if (n_defs === 1) {
-        definitions[0].classList.remove("hidden");
-      }
-      else if (n_defs <= 1) return;
+      if (n_defs === 1) definitions[0].classList.remove("hidden");
+      if (n_defs <= 1) return;
 
       let currentIndex = document.head.getAttribute("data-def-index");
       currentIndex = currentIndex % n_defs;

--- a/src/back.html
+++ b/src/back.html
@@ -69,7 +69,9 @@
         </div>
         <blockquote class="main-def def-blockquote">
             <div class="definition">
-                {{#SelectionText}}{{SelectionText}}{{/SelectionText}}
+                {{#SelectionText}}<div id="selection" class="hidden" data-display-name="Text Selection">{{SelectionText}}</div>{{/SelectionText}}
+                <div id="primary" class="hidden" data-display-name="Primary Definition">{{MainDefinition}}</div>
+                <div id="glossaries" class="hidden" data-display-name="Glossaries">{{Glossary}}</div>
             </div>
         </blockquote>
 
@@ -332,116 +334,114 @@
         return strippedContent === "" && content.match(/<\/?[^>]+(>|$)/g) !== null;
     }
 
-    // This function handles toggling definitions with click/key
-    function toggleDef(index) {
-        let dictNames = [];
-        if (`{{SelectionText}}`) dictNames.push("Text Selection");
-        if (`{{MainDefinition}}` && isAllHtml(`{{MainDefinition}}`) == false) dictNames.push("Primary Definition");
-        if (`{{Glossary}}`) dictNames.push("Glossaries");
+    function updateDefDisplay() {
+      console.log("hellooo");
+      const definitionContainer = document.querySelector(
+         ".main-def > .definition",
+      );
+      let n_children = definitionContainer.children.length;
+      if (n_children <= 1) return;
 
-        const definitionContainer = document.querySelector(
-            ".main-def > .definition",
-        );
+      const mainDefContainer = document.querySelector(".main-def");
+      let currentIndex = document.head.getAttribute("data-def-index");
 
-        const indexDisplay = document.querySelector(".def-info");
-        indexDisplay.style.opacity = 1;
+      currentIndex = currentIndex % n_children;
+      while (currentIndex < 0) currentIndex += n_children;
 
-        currentIndex = index % dictNames.length;
-        while (currentIndex < 0) currentIndex += dictNames.length;
+      console.log(currentIndex)
+      let defToDisplay = definitionContainer.children[currentIndex]
 
-        indexDisplay.innerText = `${dictNames[currentIndex]} ${currentIndex + 1}/${dictNames.length
-            }`;
 
-        if (dictNames[currentIndex].toLowerCase().includes("text selection")) {
-            definitionContainer.innerHTML = `{{SelectionText}}`;
+      for (let idx = 0; idx < n_children; idx++) {
+          definitionContainer.children[idx].classList.add("hidden");
+      }
+      defToDisplay.classList.remove("hidden");
+
+      const indexDisplay = document.querySelector(".def-info");
+      indexDisplay.style.opacity = 1;
+      indexDisplay.innerText = `${defToDisplay.getAttribute("data-display-name")} ${currentIndex + 1}/${n_children}`;
+  }
+
+  function setUpDefToggle() {
+    let mainDefContainer = document.querySelector(".main-def");
+
+    const leftEdge = document.createElement("div");
+    const rightEdge = document.createElement("div");
+    leftEdge.classList.add("left-edge");
+    leftEdge.classList.add("tappable");
+    rightEdge.classList.add("right-edge");
+    rightEdge.classList.add("tappable");
+    mainDefContainer.appendChild(leftEdge);
+    mainDefContainer.appendChild(rightEdge);
+
+    document.head.setAttribute("data-def-index", 0);
+
+    const changeIndex = (value) => {
+      // sync index
+      index = Number(document.head.getAttribute("data-def-index"));
+      index += value;
+      document.head.setAttribute("data-def-index", index);
+      updateDefDisplay();
+    };
+
+    leftEdge.addEventListener("click", (e) => changeIndex(-1));
+    rightEdge.addEventListener("click", (e) => changeIndex(1));
+
+    // Add listener only once at session start
+    if (document.head.classList.contains("has-listener") ) { return; }
+    document.addEventListener("keydown", (e) => {
+      if (e.key === "ArrowLeft") changeIndex(-1);
+      else if (e.key === "ArrowRight") changeIndex(1);
+    });
+
+    document.head.classList.add("has-listener");
+  }
+
+  // By default, it's going to be SelectionText in that field, but what if it is empty i.e user has not selected any text?
+  function showCorrectDef() {
+    const selectionText = document.querySelector(".main-def > .definition");
+    if ((selectionText.innerHTML.trim() == "" && `{{MainDefinition}}`) && isAllHtml(`{{MainDefinition}}`) == false) {
+      selectionText.innerHTML = `<div id="primary">{{MainDefinition}}</div>`;
+    }
+    else if (selectionText.innerHTML.trim() == "" && (`{{MainDefinition}}` == "" || isAllHtml(`{{MainDefinition}}`) == true))
+      selectionText.innerHTML = `<div id="glossaries">{{Glossary}}</div>`;
+  }
+
+  // This just handles clicking and showing images
+  function clickImage() {
+    const modalBg = document.querySelector(".modal-bg");
+    const imgPopup = document.querySelector(".img-popup");
+    const image = document.querySelector(".image img");
+
+    if (!image) return;
+
+    image.addEventListener("click", () => {
+        const imgPopupContainer = document.createElement("div");
+        const imgPopupImg = document.createElement("img");
+
+        imgPopupContainer.classList.add("img-popup-container");
+        imgPopupImg.src = image.src;
+        imgPopupImg.classList.add("img-popup-img");
+
+        if (image.height > image.width) {
+            imgPopupContainer.style.height = "calc(100% - 20px)";
+            imgPopupContainer.style.width = "max-content";
         }
-        else if (dictNames[currentIndex].toLowerCase().includes("primary definition")) {
-            definitionContainer.innerHTML = `<div id="primary">{{MainDefinition}}</div>`;
-            movePrimaryDicts();
-            hideCorrectDefinition();
-        }
-        else if (dictNames[currentIndex].toLowerCase().includes("glossar"))
-            definitionContainer.innerHTML = `<div id="glossaries">{{Glossary}}</div>`;
-    }
+        imgPopup.innerHTML = "";
+        imgPopup.appendChild(imgPopupContainer);
+        imgPopupContainer.appendChild(imgPopupImg);
 
-    function setUpDefToggle() {
-        const mainDefContainer = document.querySelector(".main-def");
+        document.body.classList.add("img-popup");
+        modalBg.style.display = "block";
+        imgPopupContainer.style.display = "flex";
+    });
 
-        const leftEdge = document.createElement("div");
-        const rightEdge = document.createElement("div");
-        leftEdge.classList.add("left-edge");
-        leftEdge.classList.add("tappable");
-        rightEdge.classList.add("right-edge");
-        rightEdge.classList.add("tappable");
-        mainDefContainer.appendChild(leftEdge);
-        mainDefContainer.appendChild(rightEdge);
-
-        let index = 0;
-
-        leftEdge.addEventListener("click", (e) => {
-            index -= 1;
-            toggleDef(index);
-        });
-
-        rightEdge.addEventListener("click", (e) => {
-            index += 1;
-            toggleDef(index);
-        });
-
-        document.addEventListener("keydown", (e) => {
-            const index_old = index;
-            if (e.key === "ArrowLeft") index -= 1;
-            else if (e.key === "ArrowRight") index += 1;
-
-            if (index !== index_old) toggleDef(index);
-        });
-    }
-
-    // By default, it's going to be SelectionText in that field, but what if it is empty i.e user has not selected any text?
-    function showCorrectDef() {
-        const selectionText = document.querySelector(".main-def > .definition");
-        if ((selectionText.innerHTML.trim() == "" && `{{MainDefinition}}`) && isAllHtml(`{{MainDefinition}}`) == false) {
-            selectionText.innerHTML = `<div id="primary">{{MainDefinition}}</div>`;
-        }
-        else if (selectionText.innerHTML.trim() == "" && (`{{MainDefinition}}` == "" || isAllHtml(`{{MainDefinition}}`) == true))
-            selectionText.innerHTML = `<div id="glossaries">{{Glossary}}</div>`;
-    }
-
-    // This just handles clicking and showing images
-    function clickImage() {
-        const modalBg = document.querySelector(".modal-bg");
-        const imgPopup = document.querySelector(".img-popup");
-        const image = document.querySelector(".image img");
-
-        if (!image) return;
-
-        image.addEventListener("click", () => {
-            const imgPopupContainer = document.createElement("div");
-            const imgPopupImg = document.createElement("img");
-
-            imgPopupContainer.classList.add("img-popup-container");
-            imgPopupImg.src = image.src;
-            imgPopupImg.classList.add("img-popup-img");
-
-            if (image.height > image.width) {
-                imgPopupContainer.style.height = "calc(100% - 20px)";
-                imgPopupContainer.style.width = "max-content";
-            }
-            imgPopup.innerHTML = "";
-            imgPopup.appendChild(imgPopupContainer);
-            imgPopupContainer.appendChild(imgPopupImg);
-
-            document.body.classList.add("img-popup");
-            modalBg.style.display = "block";
-            imgPopupContainer.style.display = "flex";
-        });
-
-        modalBg.addEventListener("click", () => {
-            document.body.classList.remove("img-popup");
-            modalBg.style.display = "none";
-            imgPopup.innerHTML = "";
-        });
-    }
+    modalBg.addEventListener("click", () => {
+        document.body.classList.remove("img-popup");
+        modalBg.style.display = "none";
+        imgPopup.innerHTML = "";
+    });
+  }
 
     // Handles what you see when you hover over frequency dropdown icon
     function frequencyHover() {
@@ -511,13 +511,14 @@
         tweakHTML();
         paintTargetWord();
         constructPitch();
-        showCorrectDef();
         setUpDefToggle();
+        //showCorrectDef();
         clickImage();
         frequencyHover();
         setDHHeight();
         hideCorrectDefinition();
         movePrimaryDicts();
+        updateDefDisplay(); 
     }
 
     initialize();

--- a/src/back.html
+++ b/src/back.html
@@ -334,13 +334,19 @@
 
 
   function isPrimaryEqualToGloss() {
-      const isJPMNConverted = document.querySelector("li[data-details]");
+      const isJPMNConverted = document.querySelector(".definition li[data-details]");
       if (isJPMNConverted) return false;
       // single dict formatting
       const isSingleDict = document.querySelectorAll("#glossaries > div > ol").length === 0;
       if (isSingleDict) {
           const primaryDictName = document.querySelector("#primary > div > i");
           const glossariesDictName = document.querySelector("#glossaries > div > i");
+          // {glossary-brief} and {glossary-no-dictionary} formatting
+          if (!primaryDictName || !glossariesDictName) {
+              const primaryDict = document.querySelector("#primary > div > span");
+              const glossariesDict = document.querySelector("#glossaries > div > span");
+              return primaryDict.innerHTML === glossariesDict.innerHTML
+          }
           return primaryDictName.textContent === glossariesDictName.textContent;
       }
 

--- a/src/back.html
+++ b/src/back.html
@@ -358,11 +358,6 @@
         const primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
         const glossariesDicts = document.querySelectorAll("#glossaries li[data-dictionary]");
         return primaryDicts.length === glossariesDicts.length
-        /*
-        const primaryDictsNames = Array.from(primaryDicts).map( li => li.getAttribute("data-dictionary") );
-        const glossariesDictsNames = Array.from(glossariesDicts).map( li => li.getAttribute("data-dictionary") );
-        return glossariesDictsNames.every( li => primaryDictsNames.includes(li) ); 
-        */
     }
 
     // Removes Unnecessary definitions
@@ -370,15 +365,12 @@
         const primary = document.getElementById("primary");
         const glossaries = document.getElementById("glossaries");
         if (primary && primary.textContent === "" ) {
-            console.log("primary empty");
             primary.remove()
         }
         if (glossaries && glossaries.textContent === "") {
-            console.log("gloss empty");
             glossaries.remove()
         }
         else if (primary && glossaries && isPrimaryEqualToGloss()) {
-            console.log("gloss = primary");
             glossaries.remove()
         }
     }
@@ -419,7 +411,6 @@
         if (definitions.length < 2) return;
 
         let mainDefContainer = document.querySelector(".main-def");
-
         const leftEdge = document.createElement("div");
         const rightEdge = document.createElement("div");
         leftEdge.classList.add("left-edge");
@@ -460,7 +451,7 @@
             selectionText.innerHTML = `<div id="glossaries">{{Glossary}}</div>`;
     }
 
-  // This just handles clicking and showing images
+    // This just handles clicking and showing images
     function clickImage() {
         const modalBg = document.querySelector(".modal-bg");
         const imgPopup = document.querySelector(".img-popup");
@@ -535,17 +526,17 @@
         let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
         if (primaryDicts.length === 0) return;
 
-            let style = document.createElement('style');
-            style.type = 'text/css';
+        let style = document.createElement('style');
+        style.type = 'text/css';
 
-            const cssSelector = Array.from(primaryDicts).map((dict) =>
-                `#glossaries li[data-dictionary="${dict.getAttribute("data-dictionary")}"]`
-            ).join(", ");
-            const cssRules = `${cssSelector} { display:none !important; }`;
-            style.appendChild(document.createTextNode(cssRules));
+        const cssSelector = Array.from(primaryDicts).map((dict) =>
+            `#glossaries li[data-dictionary="${dict.getAttribute("data-dictionary")}"]`
+        ).join(", ");
+        const cssRules = `${cssSelector} { display:none !important; }`;
+        style.appendChild(document.createTextNode(cssRules));
 
-            let defContainer = document.querySelector("blockquote.main-def");
-            defContainer.appendChild(style);
+        let defContainer = document.querySelector("blockquote.main-def");
+        defContainer.appendChild(style);
     }
 
     // Moves Primary Dicts into the same list

--- a/src/back.html
+++ b/src/back.html
@@ -63,17 +63,15 @@
             {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
         </div>
 
-        <!-- The entire definition blockquote -->
-        <div class="def-info-container">
-            <div class="def-info"></div>
-        </div>
-        <blockquote class="main-def def-blockquote">
-            <div class="definition">
-                {{#SelectionText}}<div id="selection" class="hidden" data-display-name="Text Selection">{{SelectionText}}</div>{{/SelectionText}}
-                <div id="primary" class="hidden" data-display-name="Primary Definition">{{MainDefinition}}</div>
-                <div id="glossaries" class="hidden" data-display-name="Glossaries">{{Glossary}}</div>
-            </div>
-        </blockquote>
+  <!-- The entire definition blockquote -->
+  <div class="def-info-container"><div class="def-info"></div></div>
+    <blockquote class="main-def def-blockquote">
+      <div class="definition">
+        {{#SelectionText}}<div id="selection" data-display-name="Text Selection">{{SelectionText}}</div>{{/SelectionText}}
+        {{#MainDefinition}}<div id="primary" data-display-name="Primary Definition">{{MainDefinition}}</div>{{/MainDefinition}}
+        <div id="glossaries" data-display-name="Glossaries">{{Glossary}}</div>
+      </div>
+    </blockquote>
 
         <!-- This is for the sentence that you see on mobile (positioned under definition), on Desktop, the sentence goes above the definition box, and this is hidden -->
         <div class="sentence-mobile">
@@ -328,41 +326,88 @@
         pitchTags.appendChild(pitchTagList);
     }
 
-    // Helper function to check if a field is just html without any content
-    function isAllHtml(content) {
-        const strippedContent = content.replace(/<\/?[^>]+(>|$)/g, "").trim();
-        return strippedContent === "" && content.match(/<\/?[^>]+(>|$)/g) !== null;
+  // Helper function to check if a field is just html without any content
+  function isAllHtml(content) {
+    const strippedContent = content.replace(/<\/?[^>]+(>|$)/g, "").trim();
+    return strippedContent === "" && content.match(/<\/?[^>]+(>|$)/g) !== null;
+  }
+
+  
+  function isPrimaryAndGlossEqual() {
+    const isJPMNConverted = document.querySelector("li[data-details]") !== null;
+    if (isJPMNConverted) return false;
+    // single dict formatting
+    const isSingleDict = document.querySelectorAll("#glossaries > div > ol").length === 0;
+    if (isSingleDict) {
+      const primary = document.querySelector("#primary > div:has(i)");
+      const glossaries = document.querySelector("#glossaries > div:has(i)");
+      return primary.innerHTML === glossaries.innerHTML;
     }
+ 
+    // multiple dicts
+    const primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
+    const primaryDictsNames = Array.from(primaryDicts).map( li => li.getAttribute("data-dictionary") );
+    const glossariesDicts = document.querySelectorAll("#glossaries li[data-dictionary]");
+    const glossariesDictsNames = Array.from(glossariesDicts).map( li => li.getAttribute("data-dictionary") );
+    return glossariesDictsNames.every( li => primaryDictsNames.includes(li) );
+  }
 
-    function updateDefDisplay() {
-      console.log("hellooo");
-      const definitionContainer = document.querySelector(
-         ".main-def > .definition",
-      );
-      let n_children = definitionContainer.children.length;
-      if (n_children <= 1) return;
-
-      const mainDefContainer = document.querySelector(".main-def");
-      let currentIndex = document.head.getAttribute("data-def-index");
-
-      currentIndex = currentIndex % n_children;
-      while (currentIndex < 0) currentIndex += n_children;
-
-      console.log(currentIndex)
-      let defToDisplay = definitionContainer.children[currentIndex]
-
-
-      for (let idx = 0; idx < n_children; idx++) {
-          definitionContainer.children[idx].classList.add("hidden");
+  // Removes Unnecessary definitions
+  function cleanDefinitions() {
+      const primary = document.getElementById("primary");
+      const glossaries = document.getElementById("glossaries");
+      if (primary && primary.innerText.trim() === "") {
+          primary.remove();
       }
-      defToDisplay.classList.remove("hidden");
+      if (glossaries && glossaries.innerText.trim() === "") {
+          glossaries.remove();
+      }
+      else if (primary && glossaries && isPrimaryAndGlossEqual()) {
+          glossaries.remove();
+      }
+  }
+
+  function updateDefDisplay() {
+      const definitions = document.querySelectorAll(
+        ".main-def > .definition > div"
+      );
+
+      let n_defs = definitions.length;
+      if (n_defs === 1) {
+        definitions[0].classList.remove("hidden");
+        return;
+      }
+      else if (n_defs < 1) return;
+
+      let currentIndex = document.head.getAttribute("data-def-index");
+      currentIndex = currentIndex % n_defs;
+      while (currentIndex < 0) currentIndex += n_defs;
+
+      for (let idx = 0; idx < n_defs; idx++) {
+          definitions[idx].classList.add("hidden");
+      }
+      definitions[currentIndex].classList.remove("hidden");
 
       const indexDisplay = document.querySelector(".def-info");
       indexDisplay.style.opacity = 1;
-      indexDisplay.innerText = `${defToDisplay.getAttribute("data-display-name")} ${currentIndex + 1}/${n_children}`;
+      indexDisplay.innerText = `${definitions[currentIndex].getAttribute("data-display-name")} \
+          ${currentIndex + 1}/${n_defs}
+      `;
   }
 
   function setUpDefToggle() {
+    document.head.setAttribute("data-def-index", 0);
+
+    cleanDefinitions();
+
+    // hide all but first def
+    let definitions = document.querySelectorAll(".main-def > .definition > div");
+    Array.from(definitions).slice(1).forEach( def => {
+        def.classList.add("hidden");
+    });
+    // nothing if no more than 1 def
+    if (definitions.length < 2) return;
+
     let mainDefContainer = document.querySelector(".main-def");
 
     const leftEdge = document.createElement("div");
@@ -373,8 +418,6 @@
     rightEdge.classList.add("tappable");
     mainDefContainer.appendChild(leftEdge);
     mainDefContainer.appendChild(rightEdge);
-
-    document.head.setAttribute("data-def-index", 0);
 
     const changeIndex = (value) => {
       // sync index
@@ -387,8 +430,8 @@
     leftEdge.addEventListener("click", (e) => changeIndex(-1));
     rightEdge.addEventListener("click", (e) => changeIndex(1));
 
-    // Add listener only once at session start
-    if (document.head.classList.contains("has-listener") ) { return; }
+    // Add key listener only once at session start
+    if (document.head.classList.contains("has-listener")) return;
     document.addEventListener("keydown", (e) => {
       if (e.key === "ArrowLeft") changeIndex(-1);
       else if (e.key === "ArrowRight") changeIndex(1);
@@ -474,16 +517,13 @@
         }
     }
 
-    // Hides the dictionary user selected in MainDefinition in Glossary field, if any
-    function hideCorrectDefinition() {
-        // Do nothing if css rule already exists
-        if (document.querySelector("blockquote.main-def style")) {
-            return;
-        }
+  // Hides the dictionary user selected in MainDefinition in Glossary field, if any
+  function hideCorrectDefinition() {
+    // Do nothing if css rule already exists
+    if (document.querySelector("blockquote.main-def style")) return;
 
-        let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
-        console.log(primaryDicts);
-        if (primaryDicts.length === 0) return;
+    let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
+    if (primaryDicts.length === 0) return;
 
         let style = document.createElement('style');
         style.type = 'text/css';
@@ -498,28 +538,28 @@
         defContainer.appendChild(style);
     }
 
-    function movePrimaryDicts() {
-        let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
-        let firstList = document.querySelector("#primary .yomitan-glossary > ol:has( li[data-dictionary])");
-        for (let idx = 1; idx < primaryDicts.length; idx++) {
-            firstList.appendChild(primaryDicts[idx]);
-        }
+  // Moves Primary Dicts into the same list
+  function movePrimaryDicts() {
+    let primaryDicts = document.querySelectorAll("#primary li[data-dictionary]");
+    let firstList = document.querySelector("#primary .yomitan-glossary > ol:has( li[data-dictionary])");
+    for (let idx = 1; idx < primaryDicts.length; idx++) {
+        firstList.appendChild(primaryDicts[idx]);
     }
+  }
 
-    // Initialize all functions!!!
-    function initialize() {
-        tweakHTML();
-        paintTargetWord();
-        constructPitch();
-        setUpDefToggle();
-        //showCorrectDef();
-        clickImage();
-        frequencyHover();
-        setDHHeight();
-        hideCorrectDefinition();
-        movePrimaryDicts();
-        updateDefDisplay(); 
-    }
+  // Initialize all functions!!!
+  function initialize() {
+    tweakHTML();
+    paintTargetWord();
+    constructPitch();
+    setUpDefToggle();
+    //showCorrectDef();
+    clickImage();
+    frequencyHover();
+    setDHHeight();
+    hideCorrectDefinition();
+    movePrimaryDicts();
+  }
 
     initialize();
 </script>

--- a/src/styling.css
+++ b/src/styling.css
@@ -734,7 +734,7 @@ li[data-dictionary^="JMdict"] i {
 }
 
 .definition .hidden {
-  display: none
+    display: none
 }
 
 /* backwards compatibility code for JPMN definitions */

--- a/src/styling.css
+++ b/src/styling.css
@@ -733,6 +733,10 @@ li[data-dictionary^="JMdict"] i {
     max-width: 300px !important;
 }
 
+.definition .hidden {
+  display: none
+}
+
 /* backwards compatibility code for JPMN definitions */
 
 li[data-details="JMdict (English)"] .dict-group__glossary>ul,


### PR DESCRIPTION
**Why Changing logic ?** 
Similar to issue #18 Current logic adds a keypress EventListener in the persistent DOM for every card.
Here's what it looks like when using an arrow key at the end of one review session (~150 cards)
![image_1734361739081_0](https://github.com/user-attachments/assets/05b14d92-e03f-49ff-979b-d21236a6db4f)
![image_1734361640417_0](https://github.com/user-attachments/assets/6acc73b7-ecfe-4aff-8711-6fcf4e490177)

**What I changed**
- Addressing EventListener issue :

Taking advantage of the persistent DOM I'm setting an attribute in the `<head>` once the listener is first attached, so I can avoid attaching it again.
Then I needed a way to make the clicks and arrowkeys share the same index, once again storing it in the persistent DOM.

- Detecting similar Primary and Glossaries :

When Multiple dicts, I figured comparing the length of the list is enough. Glossaries contains all dicts with an entry in yomitan. If primary matches that number of dicts, we know they're identical.
For single dict, I compare the content of the `<i>` tag which contains the dictionary name. Simple enough.

For an easier time of doing that I've put everything in the DOM. Instead of changing the content of the quoteblock, I'm toggling "hidden" on everything we don't want to show.
I'm removing the def element from the DOM if they're empty, this way I can avoid adding clickable edges when there is nothing to toggle to.

This makes showCorrectDef() and isAllHtml() functions unneeded.