### PR TITLE
Reading kifuku from new pitchCategories field

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ To use Lapis, first download the example deck from [Releases](https://github.com
 | IsClickCard        |                                                                                                                                                            |
 | IsSentenceCard     |                                                                                                                                                            |
 | PitchPosition      | `{pitch-accent-positions}`                                                                                                                                 |
+| PitchCategories    | `{pitch-accent-categories}`                                                                                                                                |
 | Frequency          | `{frequencies}`                                                                                                                                            |
 | FreqSort           | `{frequency-harmonic-rank}`                                                                                                                                |
 | MiscInfo           |                                                                                                                                                            |

--- a/src/back.html
+++ b/src/back.html
@@ -122,13 +122,13 @@
         const kana = `{{kana:ExpressionFurigana}}` || `{{ExpressionReading}}`;
         return (
             kana !== null &&
-            kana.replace(/[ャュョィゃゅょぃ]/g, "").length === pitchNumber
+            kana.replace(/[ァィゥェォャュョヮぁぃぅぇぉゃゅょゎ]/g, "").length === pitchNumber
         );
     }
 
-    function pitchCategories() {
+    function getPitchCategories() {
         types = "(heiban|atamadaka|nakadaka|odaka|kifuku)"
-        return [...`{{PitchPosition}}`.matchAll(types)].map( m => m[0]);
+        return [...`{{PitchCategories}}`.matchAll(types)].map( m => m[0]);
     }
 
     function endsWithAny(suffixes, string) {
@@ -138,26 +138,18 @@
         return false;
     }
 
-    function getPitchType(pitchPosition) {
-        const pitchTypes = pitchCategories();
-        const canBeKifuku = pitchTypes.includes("kifuku")
-        if (canBeKifuku) {
-            return pitchPosition === 0 ? "heiban" : "kifuku";
-        }
+    function hasVerbOrAdjEnding() {
+        return endsWithAny(
+            ["い", "う", "く", "す", "つ", "ぶ", "む", "る"],
+            "{{Expression}}".replace("</div>", "")
+        )
+    }
 
-        if (
-            endsWithAny(
-                ["い", "う", "く", "す", "つ", "ぶ", "む", "る"],
-                "{{Expression}}".replace("</div>", ""),
-            )
-        ) {
-            if (pitchPosition === 0) {
-                return "heiban";
-            } else {
-                if (pitchTypes.length == 0 || canBeKifuku) {
-                    return "kifuku";
-                }
-            }
+    function getPitchType(pitchPosition) {
+        const pitchCategories = getPitchCategories();
+        const canBeKifuku = pitchCategories.includes("kifuku")
+        if (canBeKifuku || (pitchCategories.length == 0 && hasVerbOrAdjEnding())) {
+            return pitchPosition === 0 ? "heiban" : "kifuku";
         }
 
         if (pitchPosition === 0) {
@@ -210,7 +202,7 @@
         let currentChar = "";
         let nextChar = "";
         const groupedMoras = [];
-        const check = ["ャ", "ュ", "ョ", "ィ", "ゃ", "ゅ", "ょ", "ぃ"];
+        const check = ["ァ", "ィ", "ゥ", "ェ", "ォ", "ャ", "ュ", "ョ", "ヮ", "ぁ", "ぃ", "ぅ", "ぇ", "ぉ", "ゃ", "ゅ", "ょ", "ゎ"];
 
         for (let i = 0; i < kana.length; i++) {
             currentChar = kana[i];

--- a/src/back.html
+++ b/src/back.html
@@ -126,6 +126,11 @@
         );
     }
 
+    function pitchCategories() {
+        types = "(heiban|atamadaka|nakadaka|odaka|kifuku)"
+        return [...`{{PitchPosition}}`.matchAll(types)].map( m => m[0]);
+    }
+
     function endsWithAny(suffixes, string) {
         for (let suffix of suffixes) {
             if (string.endsWith(suffix)) return true;
@@ -134,6 +139,12 @@
     }
 
     function getPitchType(pitchPosition) {
+        const pitchTypes = pitchCategories();
+        const canBeKifuku = pitchTypes.includes("kifuku")
+        if (canBeKifuku) {
+            return pitchPosition === 0 ? "heiban" : "kifuku";
+        }
+
         if (
             endsWithAny(
                 ["い", "う", "く", "す", "つ", "ぶ", "む", "る"],
@@ -143,16 +154,18 @@
             if (pitchPosition === 0) {
                 return "heiban";
             } else {
-                return "kifuku";
+                if (pitchTypes.length == 0 || canBeKifuku) {
+                    return "kifuku";
+                }
             }
-        } else {
-            if (pitchPosition === 0) {
-                return "heiban";
-            } else if (pitchPosition === 1) {
-                return "atamadaka";
-            } else if (pitchPosition > 1) {
-                return isOdaka(pitchPosition) ? "odaka" : "nakadaka";
-            }
+        }
+
+        if (pitchPosition === 0) {
+            return "heiban";
+        } else if (pitchPosition === 1) {
+            return "atamadaka";
+        } else if (pitchPosition > 1) {
+            return isOdaka(pitchPosition) ? "odaka" : "nakadaka";
         }
     }
 

--- a/src/back.html
+++ b/src/back.html
@@ -127,8 +127,8 @@
     }
 
     function getPitchCategories() {
-        types = "(heiban|atamadaka|nakadaka|odaka|kifuku)"
-        return [...`{{PitchCategories}}`.matchAll(types)].map( m => m[0]);
+        const validTypes = "(heiban|atamadaka|nakadaka|odaka|kifuku)";
+        return [...`{{PitchCategories}}`.matchAll(validTypes)].map(m => m[0]);
     }
 
     function endsWithAny(suffixes, string) {
@@ -142,12 +142,12 @@
         return endsWithAny(
             ["い", "う", "く", "す", "つ", "ぶ", "む", "る"],
             "{{Expression}}".replace("</div>", "")
-        )
+        );
     }
 
     function getPitchType(pitchPosition) {
         const pitchCategories = getPitchCategories();
-        const canBeKifuku = pitchCategories.includes("kifuku")
+        const canBeKifuku = pitchCategories.includes("kifuku");
         if (canBeKifuku || (pitchCategories.length == 0 && hasVerbOrAdjEnding())) {
             return pitchPosition === 0 ? "heiban" : "kifuku";
         }

--- a/src/front.html
+++ b/src/front.html
@@ -2,10 +2,10 @@
 <header style="visibility: hidden"></header>
 
 <main>
-    <!--------- front-vocab card ---------->
-    {{^IsSentenceCard}} {{^IsHintCard}} {{^IsClickCard}}
+    <!--------- Vocab card ---------->
+    {{^IsSentenceCard}} {{^IsWordAndSentenceCard}} {{^IsClickCard}}
     <div lang="ja" class="front-vocab">{{Expression}}</div>
-    {{/IsClickCard}} {{/IsHintCard}} {{/IsSentenceCard}}
+    {{/IsClickCard}} {{/IsWordAndSentenceCard}} {{/IsSentenceCard}}
 
     <!------- Sentence card --------->
     {{#IsSentenceCard}}
@@ -16,13 +16,13 @@
     {{/IsSentenceCard}}
 
     <!--------- Hint card ----------->
-    {{#IsHintCard}}
+    {{#IsWordAndSentenceCard}}
     <div lang="ja" class="front-vocab">{{Expression}}</div>
     <div id="hint">
         {{#SentenceFurigana}} {{kanji:SentenceFurigana}} {{/SentenceFurigana}}
         {{^SentenceFurigana}} {{kanji:Sentence}} {{/SentenceFurigana}}
     </div>
-    {{/IsHintCard}}
+    {{/IsWordAndSentenceCard}}
 
     <!-------- Click card ----------->
     {{#IsClickCard}}


### PR DESCRIPTION
Tries to handles #29
Not really happy with the code looks. We could probably rework this further to use this for all the categories.

I'm reading from PitchPosition with I've set as `{pitch-accent-positions}{pitch-accent-categories}` for this purpose.
We could change the `pitchCategories` function to use a split instead of that regex if we make a new field for categories.

Haven't tested it a lot either, but it handles おっぱい correctly.