### PR TITLE
Fix definition cut off

### DIFF
--- a/src/styling.css
+++ b/src/styling.css
@@ -364,7 +364,7 @@ header {
 /* MainDefinition */
 .definition {
     text-align: left;
-    display: inline-block;
+    width: fit-content;
     max-width: 100%;
 }
 
@@ -714,11 +714,6 @@ summary {
     display: inline;
     list-style: none;
     padding-left: 0;
-}
-
-/* fix list-number for {jitendex-brief} */
-#primary li[data-dictionary]:not(:has(> i))>span>div {
-    display: inline;
 }
 
 /* reduce indentations of Jitendex for mobile */

--- a/src/styling.css
+++ b/src/styling.css
@@ -365,6 +365,7 @@ header {
 .definition {
     text-align: left;
     display: inline-block;
+    max-width: 100%;
 }
 
 /* Definition box */
@@ -720,6 +721,12 @@ summary {
     display: inline;
 }
 
+/* reduce indentations of Jitendex for mobile */
+.mobile li[data-dictionary^="Jitendex"] ul, .mobile li[data-dictionary^="Jitendex"] ol,
+.mobile li[data-details^="Jitendex"] ul, .mobile li[data-details^="Jitendex"] ol {
+    padding-left: 0.3em;
+}
+
 /* Turn off italics */
 .definition i {
     font-style: normal;
@@ -735,6 +742,11 @@ li[data-dictionary^="JMdict"] i {
 
 .definition .hidden {
     display: none
+}
+
+/* Prevent wrapping in the middle of a Jitendex tags */
+span[data-sc-code] {
+    white-space: nowrap;
 }
 
 /* backwards compatibility code for JPMN definitions */


### PR DESCRIPTION
Fixes #44 
Also includes minor tweaks for Jitendex : 
- greatly reduce the amount of wasted space by lists in Jitendex on mobile.
- prevent Jitendex tags from wrapping.

Thanks to blooddrunk from the discord for his deck.