### PR TITLE
Removing pitch offset

### DIFF
--- a/src/back.html
+++ b/src/back.html
@@ -34,10 +34,8 @@
                 <!-- Reading + Pitch Accent -->
                 <div class="info">
                     <div class="pitch">
-                        <div style="margin-right: -15px; display: inline">
-                            {{#ExpressionFurigana}}{{kana:ExpressionFurigana}}{{/ExpressionFurigana}}
-                            {{^ExpressionFurigana}}{{ExpressionReading}}{{/ExpressionFurigana}}
-                        </div>
+                        {{#ExpressionFurigana}}{{kana:ExpressionFurigana}}{{/ExpressionFurigana}}
+                        {{^ExpressionFurigana}}{{ExpressionReading}}{{/ExpressionFurigana}}
                     </div>
 
                     <!-- Pitch Accent -->
@@ -275,15 +273,12 @@
     }
 
     function constructPitch() {
+        const pitchPositions = `{{PitchPosition}}`.match(/^\d+|\d+\b|\d+(?=\w)/g);
+        if (!pitchPositions) return;
+
         const kana = `{{kana:ExpressionFurigana}}` || `{{ExpressionReading}}`;
         const pitch = document.querySelector(".pitch");
         const pitchTags = document.querySelector("#pitch-tags");
-        const pitchPositions = `{{PitchPosition}}`.match(/^\d+|\d+\b|\d+(?=\w)/g);
-
-        if (!pitchPositions) {
-            pitch.innerHTML = `<div style="margin-right: -15px; display: inline;">${kana}</div>`;
-            return;
-        }
 
         const createPitchSpan = (pitchClass, pitchChar) => {
             const pitchSpan = document.createElement("span");


### PR DESCRIPTION
Not sure why it was there in the first place.
I also discovered that in these cases the function `pitchConstruct()` was overriding the pitch handlebar present in the html with the exact same content. So I got rid of that.

closes #55