### PR TITLE
fix portrain img on mobile and tablet

### DIFF
--- a/src/styling.css
+++ b/src/styling.css
@@ -154,7 +154,25 @@ html.mobile {
     .images-container img {
         width: 44%;
     }
+    .img-popup-container {
+        max-width: 100vw;
+        max-height: 60vh;
+      }
+    
+    .img-popup-img {
+    object-fit: contain;
+    }
 }
+
+@media (min-width: 768px) and (max-width: 1024px) {
+    .img-popup-container {
+      max-height: 70vh;
+    }
+  
+    .img-popup-img {
+      object-fit: contain;
+    }
+  }
 
 /* ----- Front elements ----- */
 


### PR DESCRIPTION
fixes #79 

also added `max-height: 70vh;` for tablets because some vertical images were to big