### PR TITLE
Fix initial definition index display

### DIFF
--- a/src/back.html
+++ b/src/back.html
@@ -411,15 +411,8 @@
         document.head.dataset.defIndex = 0;
         cleanUpDefinitions();
 
-        // hide all but first definition
-        let definitions = document.querySelectorAll(".main-def > .definition > div");
-        Array.from(definitions).slice(1).forEach(def => { def.classList.add("hidden"); });
-
-        // Ensure the index display, if relevant, is visible on initial load
+        // Show the first definition and ensure the index display, if relevant, is visible on initial load
         updateDefDisplay();
-
-        // no need for toggling on less than 2 definitions
-        if (definitions.length < 2) return;
 
         // Since <head> doesn't change through review sessions
         // Adding and checking for this class ensure each card doesn't add its own listener


### PR DESCRIPTION
I noticed that when you have multiple definitions, the index display above the definitions doesn't display until you've tried to see another definition (by clicking or with hotkeys). This makes it difficult to know if there are other definitions for a card or not, without attempting to view them first.

The issue gets resolved by calling `updateDefDisplay` in `initialize` during the initialization with the other functions, so I try doing that in this PR. Not sure if this is the ideal order in relation to the other functions, but it seems to work.

Initial load without the change:

![image](https://github.com/user-attachments/assets/2261198e-8af1-4b94-9b43-b77746151943)

Initial load with the change:

![image](https://github.com/user-attachments/assets/f38fde39-4fe9-47db-82ed-56c24074574f)

I double-checked a few more cases to confirm what they displayed on initial load too.

With `SelectionText` (while also using `MainDefinition` and `Glossary` with multiple definitions):

![image](https://github.com/user-attachments/assets/63e4306f-7e28-44bc-b9cb-e2664777b692)

Only one definition (`Glossary` = `MainDefinition`):

![image](https://github.com/user-attachments/assets/55d11ac3-041d-42ba-b208-8a85e0f26a4e)

Only `Glossary` with no `MainDefinition`:

![image](https://github.com/user-attachments/assets/205cd700-7404-44a5-aff7-db23e33b677e)
