### PR TITLE
Alt picture position

### DIFF
--- a/docs/user_settings.md
+++ b/docs/user_settings.md
@@ -7,11 +7,17 @@ Make sure you **don't forget** a _doublequote_ or a _semi-colon_ at the end of a
 
 # Settings breakdown
 
+Some of these settings have mobile version, allowing you to setup different layouts per platform.
+
 ### main-picture-position
 
-`"left"` to swap the picture and the vocabulary box.
-Valid values : `"left"`, `"right"`
-Default value : `"left"`
+Valid values : `"right"`, `"left"`, `"alt"`.
+Default value : `"right"`
+| values | behaviour |
+| ---------- | --------- |
+| `right` | Next to the vocab (default) |
+| `left` | Swaps vocab and picture |
+| `alt` | Outside of the header, next to the sentence |
 
 ### sentence-furigana
 
@@ -24,15 +30,18 @@ Default value : `"hover"`
 Displays the sentence above or below the definition box.
 Valid values : `"above"`, `"below"`
 Default value : `"above"`
+Default on mobile  : `"below"`
 
-### mobile-sentence-position
+### audio-buttons
 
-Same as above, but for mobile.
+Change the position of audio buttons
+Valid values : `"header`, `"fixed"`, `"alt"`
 
-### mobile-audio-buttons
-
-On mobile, audio play buttons are shown on the button left of the card. If you want a layout similar to desktop you can set this to `"header"`  
-Valid values : `"default"`, `"header"`
+| values | behaviour |
+| ---------- | --------- |
+| `header` | Next to the pitch |
+| `fixed` | In the bottom-left corner |
+| `alt` | Next to the sentence |
 
 ### nsfw-blur-contained
 
@@ -70,7 +79,18 @@ Default value : `"full"`
 
 Therefore, having `--jitendex-foramt: "no-forms no-sentence no-xref";` will hide forms, examples sentences and cross references.
 
+# Notable Settings
+
+You can achieve a layout similar to Lapis-modified with the following settings :
+```css
+--main-picture-position: "alt";
+--sentence-position: "below";
+--audio-buttons: "alt";
+--mobile-main-picture-position: "alt";
+--mobile-sentence-position: "below";
+--mobile-audio-buttons: "alt";
+```
+
 # Is that it ? How can I change xx or yy ?
 
 If you think you need to change something in the layout, and that it would also benefit other users of Lapis. We are open to suggestions, please open an issue.
-

--- a/docs/user_settings.md
+++ b/docs/user_settings.md
@@ -7,7 +7,7 @@ Make sure you **don't forget** a _doublequote_ or a _semi-colon_ at the end of a
 
 # Settings breakdown
 
-Some of these settings have mobile version, allowing you to setup different layouts per platform.
+All of these settings have a mobile counterpart, allowing you to setup different layouts per platform. If the one you want is not present in the file, you may have to add it yourself by prepending `mobile-` to its name.
 
 ### main-picture-position
 

--- a/src/back.html
+++ b/src/back.html
@@ -1,4 +1,4 @@
-<lapis id="lapis">
+<lapis id="lapis" lang="ja">
 <!---------- Header ------------->
     <header>
         <div class="top-container">
@@ -19,10 +19,10 @@
         </div>
     </header>
 
-    <main lang="ja">
+    <main>
         <!-- The first row (vocab box+picture) -->
         <div class="def-header">
-            <div class="dh-left">
+            <div class="dh-vocab">
                 <div class="vocab">
                     {{#ExpressionFurigana}}{{furigana:ExpressionFurigana}}{{/ExpressionFurigana}}
                     {{^ExpressionFurigana}}{{Expression}}{{/ExpressionFurigana}}
@@ -46,7 +46,7 @@
 
             <!-- Image -->
             {{#Picture}}
-            <div class="dh-right">
+            <div class="dh-image">
                 <div class="image tappable {{Tags}}">{{Picture}}</div>
             </div>
             {{/Picture}}
@@ -77,8 +77,8 @@
             </div>
         </div>
 
-        <!-- This is for the sentence that you see on mobile (positioned under definition), on Desktop, the sentence goes above the definition box, and this is hidden -->
-        <div class="sentence-mobile">
+        <!-- Alternative Sentence Position -->
+        <div class="sentence-alt">
             {{#SentenceFurigana}} {{furigana:SentenceFurigana}} {{/SentenceFurigana}}
             {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
         </div>
@@ -101,7 +101,7 @@
     </main>
 
     <!----------- Footer ------------->
-    <footer lang="ja">
+    <footer>
         <br>
         <div class="bot-container">
             {{#Tags}}
@@ -163,7 +163,7 @@
     // Show the color
     function paintTargetWord(pitchType) {
         const sentences = Array.from(
-            document.querySelectorAll(".sentence, .definition, .sentence-mobile"),
+            document.querySelectorAll(".sentence, .definition, .sentence-alt"),
         );
         for (const sentence of sentences) {
             for (const targetWord of sentence.getElementsByTagName("b")) {
@@ -495,16 +495,16 @@
         frequency.innerHTML = freqHtml;
     }
 
-    // Sets the height of dhLeft, dhRight, defHeader as a whole
+    // Sets the height of dhVocab, dhImage, defHeader as a whole
     function setDHHeight() {
-        var dhLeft = document.querySelector('.dh-left');
-        var dhRight = document.querySelector('.dh-right .image img');
+        var dhVocab = document.querySelector('.dh-vocab');
+        var dhImage = document.querySelector('.dh-image img');
         var defHeader = document.querySelector('.def-header');
 
-        if (dhLeft && dhRight) {
-            var dhLeftHeight = dhLeft.offsetHeight;
-            dhRight.style.maxHeight = `${dhLeftHeight}px`;
-            defHeader.style.maxHeight = `${dhLeftHeight}px`;
+        if (dhVocab && dhImage) {
+            var dhVocabHeight = dhVocab.offsetHeight;
+            dhImage.style.maxHeight = `${dhVocabHeight}px`;
+            defHeader.style.maxHeight = `${dhVocabHeight}px`;
         }
     }
 

--- a/src/back.html
+++ b/src/back.html
@@ -1,4 +1,4 @@
-<lapis id="lapis" lang="ja">
+<div id="lapis" lang="ja">
     <!---------- Header ------------->
     <header>
         <div class="top-container">
@@ -55,8 +55,8 @@
         <br>
         <div class="sentence">
             {{#Picture}}<div class="image-alt tappable {{Tags}}">{{Picture}}</div>{{/Picture}}
-            {{#SentenceFurigana}} {{furigana:SentenceFurigana}} {{/SentenceFurigana}}
-            {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
+                {{#SentenceFurigana}} {{furigana:SentenceFurigana}} {{/SentenceFurigana}}
+                {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
             <div class="audio-buttons-alt"></div>
         </div>
 
@@ -82,8 +82,8 @@
         <!-- Alternative Sentence Position -->
         <div class="sentence-alt">
             {{#Picture}}<div class="image-alt tappable {{Tags}}">{{Picture}}</div>{{/Picture}}
-            {{#SentenceFurigana}} {{furigana:SentenceFurigana}} {{/SentenceFurigana}}
-            {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
+                {{#SentenceFurigana}} {{furigana:SentenceFurigana}} {{/SentenceFurigana}}
+                {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
             <div class="audio-buttons-alt"></div>
         </div>
 
@@ -115,7 +115,7 @@
             {{/Tags}}
         </div>
     </footer>
-</lapis>
+</div>
 
 <!----------- Scripts ------------>
 <script>

--- a/src/back.html
+++ b/src/back.html
@@ -78,7 +78,6 @@
                 <div id="glossaries" data-display-name="Glossaries">{{Glossary}}</div>
             </div>
         </div>
-        <br>
 
         <!-- Alternative Sentence Position -->
         <div class="sentence-alt">
@@ -567,7 +566,7 @@
         ];
         for (const opt of options) {
             let value = styles.getPropertyValue(opt);
-            value = value.replace(/^"([^"]*)"$/, '$1').trim().toLowerCase();
+            value = value.replace(/^['"]|['"]$/g,"").trim().toLowerCase();
             lapis.setAttribute("data-" + opt.slice(2), value);
             if (opt === "--open-misc-info" && value === "on" && miscInfo) {
                 miscInfo.open = true;

--- a/src/back.html
+++ b/src/back.html
@@ -578,6 +578,7 @@
     // Initialize all functions!!!
     function initialize() {
         addAudioButtons();
+        userSettings();
         splitTags();
         handlePitches();
         setUpDefToggle();
@@ -586,7 +587,6 @@
         setDHHeight();
         hideCorrectDefinition();
         movePrimaryDicts();
-        userSettings();
     }
 
     initialize();

--- a/src/back.html
+++ b/src/back.html
@@ -539,12 +539,11 @@
         }
     }
 
+    // Read user settings and set them as html attributes
     function userSettings() {
-        const oldSettings = document.querySelector("settings");
-        // Needed to give user instant feedback on their changes
-        oldSettings?.remove();
-
-        const settings = document.createElement("settings");
+        const styles = getComputedStyle(document.documentElement);
+        const miscInfo = document.querySelector("details:has(.misc-info)");
+        const lapis = document.getElementById("lapis");
         const options = [
             "--main-picture-position",
             "--sentence-furigana",
@@ -556,16 +555,14 @@
             "--glossary-separator",
             "--jitendex-format"
         ];
-        for (let opt of options) {
-            const value = getComputedStyle(document.documentElement).getPropertyValue(opt).trim();
-            settings.setAttribute("data-" + opt.slice(2), value.slice(1, -1));
-            if (opt === "--open-misc-info" && value === "\"on\"") {
-                const miscInfo = document.querySelector("details:has(.misc-info)");
-                if (miscInfo) miscInfo.open = true;
+        for (const opt of options) {
+            let value = styles.getPropertyValue(opt);
+            value = value.replace(/^"([^"]*)"$/, '$1').trim().toLowerCase();
+            lapis.setAttribute("data-" + opt.slice(2), value);
+            if (opt === "--open-misc-info" && value === "on" && miscInfo) {
+                miscInfo.open = true;
             }
         }
-        const lapis = document.getElementById("lapis");
-        lapis.parentElement.insertBefore(settings, lapis);
     }
 
     // Initialize all functions!!!

--- a/src/back.html
+++ b/src/back.html
@@ -1,5 +1,5 @@
 <lapis id="lapis" lang="ja">
-<!---------- Header ------------->
+    <!---------- Header ------------->
     <header>
         <div class="top-container">
             <!-- Show the frequency number -->
@@ -40,7 +40,7 @@
                     <span id="pitch-tags" class="tags"> {{PitchPosition}} </span>
                     {{/PitchPosition}}
                     <br />
-                    <div class="audio-buttons">{{ExpressionAudio}} {{SentenceAudio}}</div>
+                    <div class="audio-buttons"></div>
                 </div>
             </div>
 
@@ -54,8 +54,10 @@
 
         <br>
         <div class="sentence">
+            {{#Picture}}<div class="image-alt tappable {{Tags}}">{{Picture}}</div>{{/Picture}}
             {{#SentenceFurigana}} {{furigana:SentenceFurigana}} {{/SentenceFurigana}}
             {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
+            <div class="audio-buttons-alt"></div>
         </div>
 
         <!-- The entire definition box -->
@@ -76,11 +78,14 @@
                 <div id="glossaries" data-display-name="Glossaries">{{Glossary}}</div>
             </div>
         </div>
+        <br>
 
         <!-- Alternative Sentence Position -->
         <div class="sentence-alt">
+            {{#Picture}}<div class="image-alt tappable {{Tags}}">{{Picture}}</div>{{/Picture}}
             {{#SentenceFurigana}} {{furigana:SentenceFurigana}} {{/SentenceFurigana}}
             {{^SentenceFurigana}} {{furigana:Sentence}} {{/SentenceFurigana}}
+            <div class="audio-buttons-alt"></div>
         </div>
 
         <!------- Image modal --------->
@@ -115,6 +120,12 @@
 
 <!----------- Scripts ------------>
 <script>
+    // Hack to add multiple buttons without Anki playing them multiple times
+    function addAudioButtons() {
+        const audioContainers = document.querySelectorAll(".audio-buttons, .audio-buttons-alt");
+        audioContainers.forEach(audio => audio.innerHTML = `{{ExpressionAudio}}{{SentenceAudio}}`);
+    }
+
     // This code is concerned with calculating the Pitch Accent and constructing the pitch accent graphs
     function isOdaka(pitchNumber) {
         const kana = `{{kana:ExpressionFurigana}}` || `{{ExpressionReading}}`;
@@ -548,8 +559,7 @@
             "--main-picture-position",
             "--sentence-furigana",
             "--sentence-position",
-            "--mobile-sentence-position",
-            "--mobile-audio-buttons",
+            "--audio-buttons",
             "--nsfw-blur-contained",
             "--open-misc-info",
             "--glossary-separator",
@@ -567,6 +577,7 @@
 
     // Initialize all functions!!!
     function initialize() {
+        addAudioButtons();
         splitTags();
         handlePitches();
         setUpDefToggle();

--- a/src/back.html
+++ b/src/back.html
@@ -174,7 +174,7 @@
     // Show the color
     function paintTargetWord(pitchType) {
         const sentences = Array.from(
-            document.querySelectorAll(".sentence, .definition, .sentence-alt"),
+            document.querySelectorAll(".sentence, .sentence-alt, .definition"),
         );
         for (const sentence of sentences) {
             for (const targetWord of sentence.getElementsByTagName("b")) {
@@ -441,7 +441,7 @@
     function clickImages() {
         const modalBg = document.querySelector(".modal-bg");
         const imgPopup = document.querySelector(".img-popup");
-        const images = Array.from(document.querySelectorAll(".image img, .def-image img"));
+        const images = Array.from(document.querySelectorAll(".image img, .image-alt img, .def-image img"));
 
         if (images.length < 1) return;
 

--- a/src/front.html
+++ b/src/front.html
@@ -1,4 +1,4 @@
-<lapis id="lapis">
+<div id="lapis">
     <!---------- Header ------------->
     <header style="visibility: hidden"></header>
 
@@ -44,7 +44,7 @@
     <div id="hint">{{Hint}}</div>
     {{/Hint}}
     </main>
-</lapis>
+</div>
 
 <script>
   function ClickCard() {

--- a/src/styling.css
+++ b/src/styling.css
@@ -511,7 +511,7 @@ main {
   transition: filter 0.3s;
 }
 
-.image-alt {
+.image-alt img {
     margin: auto;
     max-width: 60%;
     max-height: 30vh;

--- a/src/styling.css
+++ b/src/styling.css
@@ -37,16 +37,20 @@
   --def-picture-size: 200px;
   --max-width: 800px;
 
-  /* See https://github.com/donkuri/lapis/tree/main/docs/user_settings.md for an overview of these variables */
-  --main-picture-position: "right"; /* "right", "left" */
-  --sentence-furigana: "hover"; /* "hover", "always", "off" */
+  /* For an overview of these variables
+  See https://github.com/donkuri/lapis/tree/main/docs/user_settings.md */
+  --main-picture-position: "right"; /* "right", "left", "alt" */
   --sentence-position: "above"; /* "above", "below" the definition box*/
-  --mobile-sentence-position: "below";
-  --mobile-audio-buttons: "default"; /* "default", "header" (inside vocabulary box) */
+  --audio-buttons: "header"; /* "header", "fixed", "alt" */
+  --sentence-furigana: "hover"; /* "hover", "always", "off" */
   --nsfw-blur-contained: "off"; /* "on", "off" */
   --open-misc-info: "off"; /* "on", "off" */
   --glossary-separator: "off"; /* "on" to separate dictionaries in definition box */
   --jitendex-format: "full"; /* "minimal" or space-separated list of "no-tags", "no-sentence", "no-forms", "no-xref", "no-img" */
+
+  --mobile-main-picture-position: "right"; /* "left", "right", "alt" */
+  --mobile-sentence-position: "below";
+  --mobile-audio-buttons: "fixed"; /* "fixed", "header", "alt" */
 
   /* Pitch colors */
   --dark-mode-heiban: #39bae6;
@@ -193,9 +197,7 @@
   --skogo-gendai-mark: #888;
 }
 
-html.win,
-html.mac,
-html.linux:not(.android) {
+html {
   --main-font-size: var(--pc-main-font-size);
   --main-def-size: var(--pc-main-def-size);
   --vocab-font-size: var(--pc-vocab-font-size);
@@ -215,6 +217,9 @@ html.mobile {
   --back-sentence-font-size: var(--mobile-back-sentence-font-size);
   --hint-font-size: var(--mobile-hint-font-size);
   --info-font-size: var(--mobile-info-font-size);
+  --main-picture-position: var(--mobile-main-picture-position);
+  --sentence-position: var(--mobile-sentence-position);
+  --audio-buttons: var(--mobile-audio-buttons);
 }
 
 #lapis {
@@ -498,7 +503,7 @@ main {
 }
 
 /* Primary Image */
-.image img {
+.image img, .image-alt img {
   max-height: 400px;
   width: auto;
   border-radius: 5px;
@@ -506,7 +511,14 @@ main {
   transition: filter 0.3s;
 }
 
+.image-alt {
+    margin: auto;
+    max-width: 60%;
+    max-height: 30vh;
+}
+
 .image img:hover,
+.image-alt img:hover,
 .def-image img:hover {
   filter: brightness(var(--image-brightness));
 }
@@ -613,11 +625,6 @@ main {
   & ruby:hover rt {
     visibility: visible;
   }
-}
-
-.mobile .sentence,
-html:not(.mobile) .sentence-alt {
-  display: none;
 }
 
 /* Footer */
@@ -1068,14 +1075,48 @@ li[data-dictionary="旺文社 全訳古語辞典"] div[data-sc小倉囲み-g] {
   color: #1e1e1e !important;
 }
 
+/* Default Layouts */
+html.mobile .sentence, html:not(.mobile) .sentence-alt,
+.audio-buttons-alt, .image-alt {
+  display: none;
+}
+
 /*
  *  USER SETTINGS
  *  Please modify the variables at the top of the file.
  */
-lapis[data-main-picture-position="left"] .def-header {
+/* Layout changes */
+ lapis[data-main-picture-position="left"] .def-header {
   flex-flow: row-reverse;
 }
 
+lapis[data-main-picture-position="alt"] .dh-image,
+lapis[data-audio-buttons="alt"] .audio-buttons,
+lapis[data-sentence-position="above"] .sentence-alt,
+lapis[data-sentence-position="below"] .sentence {
+  display: none;
+}
+
+lapis[data-main-picture-position="alt"] .image-alt,
+lapis[data-audio-buttons="alt"] .audio-buttons-alt,
+lapis[data-sentence-position="above"] .sentence,
+lapis[data-sentence-position="below"] .sentence-alt {
+  display: block;
+}
+
+/* Audio Buttons Settings */
+lapis[data-audio-buttons="fixed"] .audio-buttons {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  z-index: 1000;
+}
+
+lapis[data-audio-buttons="header"] .audio-buttons {
+  position: static;
+}
+
+/* Other Settings */
 lapis[data-sentence-furigana="always"] .sentence rt,
 lapis[data-sentence-furigana="always"] .sentence-alt rt {
   visibility: visible;
@@ -1084,20 +1125,6 @@ lapis[data-sentence-furigana="always"] .sentence-alt rt {
 lapis[data-sentence-furigana="off"] .sentence rt,
 lapis[data-sentence-furigana="off"] .sentence-alt rt {
   display: none;
-}
-
-html.mobile lapis[data-mobile-sentence-position="above"] .sentence-alt,
-html:not(.mobile) lapis[data-sentence-position="below"] .sentence {
-  display: none;
-}
-
-html.mobile lapis[data-mobile-sentence-position="above"] .sentence,
-html:not(.mobile) lapis[data-sentence-position="below"] .sentence-alt {
-  display: block;
-}
-
-html.mobile lapis[data-mobile-audio-buttons="header"] .audio-buttons {
-  position: static;
 }
 
 lapis[data-nsfw-blur-contained="on"] .NSFW,
@@ -1113,10 +1140,12 @@ lapis[data-glossary-separator="on"] .definition {
   }
 }
 
-lapis[data-jitendex-format~="minimal"] .definition {
-  & [data-sc-content]:not([data-sc-content="glossary"]) {
-    display: none;
-  }
+lapis[data-jitendex-format~="minimal"] .definition [data-sc-content]:not([data-sc-content="glossary"]),
+lapis[data-jitendex-format~="no-sentence"] .definition [data-sc-content|="example-sentence"],
+lapis[data-jitendex-format~="no-forms"] .definition [data-sc-content="forms"],
+lapis[data-jitendex-format~="no-xref"] .definition [data-sc-content|="xref"],
+lapis[data-jitendex-format~="no-img"] .definition [data-sc-content|="graphic"] {
+  display: none; 
 }
 
 lapis[data-jitendex-format~="minimal"] .definition,
@@ -1130,29 +1159,5 @@ lapis[data-jitendex-format~="no-tags"] .definition {
     & > li::marker {
       content: "";
     }
-  }
-}
-
-lapis[data-jitendex-format~="no-sentence"] .definition {
-  & [data-sc-content|="example-sentence"] {
-    display: none;
-  }
-}
-
-lapis[data-jitendex-format~="no-forms"] .definition {
-  & [data-sc-content="forms"] {
-    display: none;
-  }
-}
-
-lapis[data-jitendex-format~="no-xref"] .definition {
-  & [data-sc-content|="xref"] {
-    display: none;
-  }
-}
-
-lapis[data-jitendex-format~="no-img"] .definition {
-  & [data-sc-content|="graphic"] {
-    display: none;
   }
 }

--- a/src/styling.css
+++ b/src/styling.css
@@ -600,7 +600,7 @@ main {
 
 /* Back sentence */
 .sentence,
-.sentence-mobile {
+.sentence-alt {
   line-height: 1.5;
   font-size: var(--back-sentence-font-size);
   display: inline-block;
@@ -616,7 +616,7 @@ main {
 }
 
 .mobile .sentence,
-html:not(.mobile) .sentence-mobile {
+html:not(.mobile) .sentence-alt {
   display: none;
 }
 
@@ -676,7 +676,7 @@ footer {
   gap: min(20px, 2vw);
 }
 
-.dh-left {
+.dh-vocab {
   /* left */
   background: var(--bg-elevated);
   padding: 0.52em;
@@ -685,24 +685,24 @@ footer {
   /* takes up all available space */
 }
 
-.dh-right {
+.dh-image {
   max-width: 400px;
   position: relative;
   font-size: 0;
   /* weird hack needed to make the image stay in line with the .def-header */
 }
 
-.mobile .dh-left {
+.mobile .dh-vocab {
   background: none;
   padding: 0em;
   border-radius: 0px;
 }
 
-.mobile .dh-left:has(~ .dh-right) {
+.mobile .dh-vocab:has(~ .dh-image) {
   max-width: 60vw;
 }
 
-.mobile .dh-right {
+.mobile .dh-image {
   max-width: 40vw;
 }
 
@@ -1077,22 +1077,22 @@ lapis[data-main-picture-position="left"] .def-header {
 }
 
 lapis[data-sentence-furigana="always"] .sentence rt,
-lapis[data-sentence-furigana="always"] .sentence-mobile rt {
+lapis[data-sentence-furigana="always"] .sentence-alt rt {
   visibility: visible;
 }
 
 lapis[data-sentence-furigana="off"] .sentence rt,
-lapis[data-sentence-furigana="off"] .sentence-mobile rt {
+lapis[data-sentence-furigana="off"] .sentence-alt rt {
   display: none;
 }
 
-html.mobile lapis[data-mobile-sentence-position="above"] .sentence-mobile,
+html.mobile lapis[data-mobile-sentence-position="above"] .sentence-alt,
 html:not(.mobile) lapis[data-sentence-position="below"] .sentence {
   display: none;
 }
 
 html.mobile lapis[data-mobile-sentence-position="above"] .sentence,
-html:not(.mobile) lapis[data-sentence-position="below"] .sentence-mobile {
+html:not(.mobile) lapis[data-sentence-position="below"] .sentence-alt {
   display: block;
 }
 

--- a/src/styling.css
+++ b/src/styling.css
@@ -1072,55 +1072,55 @@ li[data-dictionary="旺文社 全訳古語辞典"] div[data-sc小倉囲み-g] {
  *  USER SETTINGS
  *  Please modify the variables at the top of the file.
  */
-settings[data-main-picture-position="left"] + lapis .def-header {
+lapis[data-main-picture-position="left"] .def-header {
   flex-flow: row-reverse;
 }
 
-settings[data-sentence-furigana="always"] + lapis .sentence rt,
-settings[data-sentence-furigana="always"] + lapis .sentence-mobile rt {
+lapis[data-sentence-furigana="always"] .sentence rt,
+lapis[data-sentence-furigana="always"] .sentence-mobile rt {
   visibility: visible;
 }
 
-settings[data-sentence-furigana="off"] + lapis .sentence rt,
-settings[data-sentence-furigana="off"] + lapis .sentence-mobile rt {
+lapis[data-sentence-furigana="off"] .sentence rt,
+lapis[data-sentence-furigana="off"] .sentence-mobile rt {
   display: none;
 }
 
-html.mobile settings[data-mobile-sentence-position="above"] + lapis .sentence-mobile,
-html:not(.mobile) settings[data-sentence-position="below"] + lapis .sentence {
+html.mobile lapis[data-mobile-sentence-position="above"] .sentence-mobile,
+html:not(.mobile) lapis[data-sentence-position="below"] .sentence {
   display: none;
 }
 
-html.mobile settings[data-mobile-sentence-position="above"] + lapis .sentence,
-html:not(.mobile) settings[data-sentence-position="below"] + lapis .sentence-mobile {
+html.mobile lapis[data-mobile-sentence-position="above"] .sentence,
+html:not(.mobile) lapis[data-sentence-position="below"] .sentence-mobile {
   display: block;
 }
 
-html.mobile settings[data-mobile-audio-buttons="header"] + lapis .audio-buttons {
+html.mobile lapis[data-mobile-audio-buttons="header"] .audio-buttons {
   position: static;
 }
 
-settings[data-nsfw-blur-contained="on"] + lapis .NSFW,
-settings[data-nsfw-blur-contained="on"] + lapis .nsfw,
-settings[data-nsfw-blur-contained="on"] + lapis .Nsfw {
+lapis[data-nsfw-blur-contained="on"] .NSFW,
+lapis[data-nsfw-blur-contained="on"] .nsfw,
+lapis[data-nsfw-blur-contained="on"] .Nsfw {
   overflow: hidden;
 }
 
-settings[data-glossary-separator="on"] + lapis .definition {
+lapis[data-glossary-separator="on"] .definition {
   & li[data-dictionary]:not(:last-of-type),
   & li[data-details]:not(:last-of-type) {
     border-bottom: 1px dashed var(--fg-subtle);
   }
 }
 
-settings[data-jitendex-format~="minimal"] + lapis .definition {
+lapis[data-jitendex-format~="minimal"] .definition {
   & [data-sc-content]:not([data-sc-content="glossary"]) {
     display: none;
   }
 }
 
-settings[data-jitendex-format~="minimal"] + lapis .definition,
-settings[data-jitendex-format~="no-tags"] + lapis .definition {
+lapis[data-jitendex-format~="minimal"] .definition,
+lapis[data-jitendex-format~="no-tags"] .definition {
   & [data-sc-code] {
     display: none;
   }
@@ -1133,25 +1133,25 @@ settings[data-jitendex-format~="no-tags"] + lapis .definition {
   }
 }
 
-settings[data-jitendex-format~="no-sentence"] + lapis .definition {
+lapis[data-jitendex-format~="no-sentence"] .definition {
   & [data-sc-content|="example-sentence"] {
     display: none;
   }
 }
 
-settings[data-jitendex-format~="no-forms"] + lapis .definition {
+lapis[data-jitendex-format~="no-forms"] .definition {
   & [data-sc-content="forms"] {
     display: none;
   }
 }
 
-settings[data-jitendex-format~="no-xref"] + lapis .definition {
+lapis[data-jitendex-format~="no-xref"] .definition {
   & [data-sc-content|="xref"] {
     display: none;
   }
 }
 
-settings[data-jitendex-format~="no-img"] + lapis .definition {
+lapis[data-jitendex-format~="no-img"] .definition {
   & [data-sc-content|="graphic"] {
     display: none;
   }

--- a/src/styling.css
+++ b/src/styling.css
@@ -443,7 +443,7 @@ main {
   text-align: left;
   border-left: 5px solid #ccc;
   padding: 0.5em 10px;
-  margin: 5px auto;
+  margin: 5px auto 10px auto;
   overflow: hidden;
   position: relative;
 }
@@ -512,9 +512,10 @@ main {
 }
 
 .image-alt img {
-    margin: auto;
-    max-width: 60%;
-    max-height: 30vh;
+  margin: auto;
+  max-width: 60%;
+  max-height: 30vh;
+  border: solid var(--fg-subtle) 2px;
 }
 
 .image img:hover,

--- a/src/styling.css
+++ b/src/styling.css
@@ -388,6 +388,10 @@ main {
   z-index: 1000;
 }
 
+.audio-buttons-alt {
+    font-size: 0;
+}
+
 /* Pitch */
 .pitch {
   display: inline;
@@ -514,8 +518,9 @@ main {
 .image-alt img {
   margin: auto;
   max-width: 60%;
-  max-height: 30vh;
+  max-height: 250px;
   border: solid var(--fg-subtle) 2px;
+  font-size: 0;
 }
 
 .image img:hover,
@@ -685,7 +690,6 @@ footer {
 }
 
 .dh-vocab {
-  /* left */
   background: var(--bg-elevated);
   padding: 0.52em;
   border-radius: 5px;
@@ -1087,70 +1091,70 @@ html.mobile .sentence, html:not(.mobile) .sentence-alt,
  *  Please modify the variables at the top of the file.
  */
 /* Layout changes */
- lapis[data-main-picture-position="left"] .def-header {
+#lapis[data-main-picture-position="left"] .def-header {
   flex-flow: row-reverse;
 }
 
-lapis[data-main-picture-position="alt"] .dh-image,
-lapis[data-audio-buttons="alt"] .audio-buttons,
-lapis[data-sentence-position="above"] .sentence-alt,
-lapis[data-sentence-position="below"] .sentence {
+#lapis[data-main-picture-position="alt"] .dh-image,
+#lapis[data-audio-buttons="alt"] .audio-buttons,
+#lapis[data-sentence-position="above"] .sentence-alt,
+#lapis[data-sentence-position="below"] .sentence {
   display: none;
 }
 
-lapis[data-main-picture-position="alt"] .image-alt,
-lapis[data-audio-buttons="alt"] .audio-buttons-alt,
-lapis[data-sentence-position="above"] .sentence,
-lapis[data-sentence-position="below"] .sentence-alt {
+#lapis[data-main-picture-position="alt"] .image-alt,
+#lapis[data-audio-buttons="alt"] .audio-buttons-alt,
+#lapis[data-sentence-position="above"] .sentence,
+#lapis[data-sentence-position="below"] .sentence-alt {
   display: block;
 }
 
 /* Audio Buttons Settings */
-lapis[data-audio-buttons="fixed"] .audio-buttons {
+#lapis[data-audio-buttons="fixed"] .audio-buttons {
   position: fixed;
   bottom: 0;
   left: 0;
   z-index: 1000;
 }
 
-lapis[data-audio-buttons="header"] .audio-buttons {
+#lapis[data-audio-buttons="header"] .audio-buttons {
   position: static;
 }
 
 /* Other Settings */
-lapis[data-sentence-furigana="always"] .sentence rt,
-lapis[data-sentence-furigana="always"] .sentence-alt rt {
+#lapis[data-sentence-furigana="always"] .sentence rt,
+#lapis[data-sentence-furigana="always"] .sentence-alt rt {
   visibility: visible;
 }
 
-lapis[data-sentence-furigana="off"] .sentence rt,
-lapis[data-sentence-furigana="off"] .sentence-alt rt {
+#lapis[data-sentence-furigana="off"] .sentence rt,
+#lapis[data-sentence-furigana="off"] .sentence-alt rt {
   display: none;
 }
 
-lapis[data-nsfw-blur-contained="on"] .NSFW,
-lapis[data-nsfw-blur-contained="on"] .nsfw,
-lapis[data-nsfw-blur-contained="on"] .Nsfw {
+#lapis[data-nsfw-blur-contained="on"] .NSFW,
+#lapis[data-nsfw-blur-contained="on"] .nsfw,
+#lapis[data-nsfw-blur-contained="on"] .Nsfw {
   overflow: hidden;
 }
 
-lapis[data-glossary-separator="on"] .definition {
+#lapis[data-glossary-separator="on"] .definition {
   & li[data-dictionary]:not(:last-of-type),
   & li[data-details]:not(:last-of-type) {
     border-bottom: 1px dashed var(--fg-subtle);
   }
 }
 
-lapis[data-jitendex-format~="minimal"] .definition [data-sc-content]:not([data-sc-content="glossary"]),
-lapis[data-jitendex-format~="no-sentence"] .definition [data-sc-content|="example-sentence"],
-lapis[data-jitendex-format~="no-forms"] .definition [data-sc-content="forms"],
-lapis[data-jitendex-format~="no-xref"] .definition [data-sc-content|="xref"],
-lapis[data-jitendex-format~="no-img"] .definition [data-sc-content|="graphic"] {
+#lapis[data-jitendex-format~="minimal"] .definition [data-sc-content]:not([data-sc-content="glossary"]),
+#lapis[data-jitendex-format~="no-sentence"] .definition [data-sc-content|="example-sentence"],
+#lapis[data-jitendex-format~="no-forms"] .definition [data-sc-content="forms"],
+#lapis[data-jitendex-format~="no-xref"] .definition [data-sc-content|="xref"],
+#lapis[data-jitendex-format~="no-img"] .definition [data-sc-content|="graphic"] {
   display: none; 
 }
 
-lapis[data-jitendex-format~="minimal"] .definition,
-lapis[data-jitendex-format~="no-tags"] .definition {
+#lapis[data-jitendex-format~="minimal"] .definition,
+#lapis[data-jitendex-format~="no-tags"] .definition {
   & [data-sc-code] {
     display: none;
   }


### PR DESCRIPTION
Allows users to have the main picture and audio buttons outside of the header. Also giving them the choice of defining different layouts for mobile and desktop.
Also renamed "default" settings options, as they were unclear.

<img width="942" height="1024" alt="image" src="https://github.com/user-attachments/assets/1c2f7bd3-7167-477c-b35d-ec663e0fdf25" />
- Picture with sentence above defs.

<img width="942" height="1024" alt="image" src="https://github.com/user-attachments/assets/f91efbe5-d431-4eed-97ee-9f5c60ed93f4" />
- Picture with sentence below defs and audio buttons in the vocab box.