### PR TITLE
Make images within definitions clickable

### DIFF
--- a/src/back.html
+++ b/src/back.html
@@ -430,17 +430,20 @@
     function clickImages() {
         const modalBg = document.querySelector(".modal-bg");
         const imgPopup = document.querySelector(".img-popup");
-        const images = Array.from(document.querySelectorAll(".image img, .def-image img"));
+        let images = Array.from(document.querySelectorAll(".image img, .def-image img"));
+        /* Disable image links that were opening in a browser window */
+        const glossImageLinks = document.querySelectorAll(".definition a:has(img)");
+        glossImageLinks.forEach(link => link.href = "");
 
-        if (images.length < 1) return;
-
+        images = [... images, ... glossImageLinks];
+        if(images.length < 1) return;
         for (let image of images) {
             image.addEventListener("click", () => {
                 const imgPopupContainer = document.createElement("div");
                 const imgPopupImg = document.createElement("img");
 
                 imgPopupContainer.classList.add("img-popup-container");
-                imgPopupImg.src = image.src;
+                imgPopupImg.src = image.src || image.querySelector("img").src;
                 imgPopupImg.classList.add("img-popup-img");
 
                 if (image.height > image.width) {


### PR DESCRIPTION
I hate how clicking on a image from glossaries opens up a new tab in a browser.
This disable the link that opened the browser and displays them in the modal instead.

<img width="942" height="1024" alt="image" src="https://github.com/user-attachments/assets/bddee7fa-d52c-4999-a310-123b2c0308b4" />