### PR TITLE
Fix some blur issues

### DIFF
--- a/src/styling.css
+++ b/src/styling.css
@@ -510,12 +510,16 @@ main {
 }
 
 /* Primary Image */
-.image img, .image-alt img {
-  max-height: 400px;
-  width: auto;
+.image, .image-alt {
   border-radius: 5px;
-  cursor: pointer;
-  transition: filter 0.3s;
+
+  & img {
+    max-height: 400px;
+    width: auto;
+    border-radius: 5px;
+    cursor: pointer;
+    transition: filter 0.3s;
+  }
 }
 
 .image-alt img {

--- a/src/styling.css
+++ b/src/styling.css
@@ -522,12 +522,18 @@ main {
   }
 }
 
-.image-alt img {
+.image-alt {
   margin: auto;
+  margin-bottom: 10px;
+  width: fit-content;
   max-width: 60%;
-  max-height: 250px;
-  border: solid var(--fg-subtle) 2px;
   font-size: 0;
+
+  & img {
+    max-height: 250px;
+    border: solid var(--fg-subtle) 2px;
+    box-sizing: border-box;
+  }
 }
 
 .image img:hover,


### PR DESCRIPTION
The first commit makes the design consistent by making the blurred image have rounded corners
Before:
<img width="829" height="231" alt="3HGqdzfFWI" src="https://github.com/user-attachments/assets/e05e5c4a-395a-4001-94fa-978dd4590500" />
After:
<img width="835" height="234" alt="ULTmrMAPmp" src="https://github.com/user-attachments/assets/91188ea2-82bc-4bf6-a72c-efb134e474f7" />
The second commit fixes main-picture-position: "alt" when it is paired with "nsfw-blur-contained: "on"
Before:
<img width="877" height="847" alt="pythonw_Ib2zVLzEmf" src="https://github.com/user-attachments/assets/d5b6e4b2-6a31-4c0e-b3f0-ad6d982a53aa" />
After:
<img width="892" height="842" alt="WqrW7gf5Lo" src="https://github.com/user-attachments/assets/928acbf4-aa57-4853-aa56-f6316d0692ac" />
Due to font-size: 0 now being on the container, there is some lost margin that needs to be manually added back.