### PR TITLE
Do multiple image resize passes in setDHHeight if necessary

### DIFF
--- a/src/back.html
+++ b/src/back.html
@@ -487,14 +487,20 @@
 
     // Sets the height of dhVocab, dhImage, defHeader as a whole
     function setDHHeight() {
-        var dhVocab = document.querySelector('.dh-vocab');
-        var dhImage = document.querySelector('.dh-image img');
-        var defHeader = document.querySelector('.def-header');
+        const dhVocab = document.querySelector('.dh-vocab');
+        const dhImage = document.querySelector('.dh-image img');
 
-        if (dhVocab && dhImage) {
-            var dhVocabHeight = dhVocab.offsetHeight;
+        if (!dhVocab || !dhImage) return;
+
+        // After an image is resized to fit, the vocab height may change due to text wrapping differences.
+        // The image then needs resized again, but the process should stabilize within a couple iterations.
+        let previousHeight = -1;
+        for (let i = 0; i < 3; i++) {
+            const dhVocabHeight = dhVocab.offsetHeight;
+            if (dhVocabHeight === previousHeight) break;
+
+            previousHeight = dhVocabHeight
             dhImage.style.maxHeight = `${dhVocabHeight}px`;
-            defHeader.style.maxHeight = `${dhVocabHeight}px`;
         }
     }
 


### PR DESCRIPTION
## Summary

Addresses #143 and solution originally discussed in #144.

An image can have an aspect ratio such that it causes the vocab section to wrap its text but then when the image is resized down to fit its height to the vocab section during initialization it gives the vocab section enough extra width to no longer need wrapping (and thus the vocab section grows horizontally and shrinks vertically). That results in the image matching the wrapped vocab section's height rather than the final vocab section's height (i.e. too big).

To resolve that, we do multiple passes on the resizing. The first pass should resize the image small enough to unwrap text in similar situations so that the second pass will resize the image to properly match the final desired size. I made it do 3 passes overall "just in case" there is an unexpected need for another iteration while still staying fully bounded, and it terminates the loop early if fewer are needed anyway.

Note that this just sets the `max-height` of the image for limiting its height to only ever get as tall as the vocab section, but it does not guarantee the image will be as tall as that section (e.g. if it's wider than it is tall, it may still only use part of the vertical space).

The line of ``defHeader.style.maxHeight = `${dhVocabHeight}px`;`` was removed as it should not be needed, since the header will size itself as its contents (vocab / image) get resized.

## Testing

あっという間, the known affected card from the original issue, now visually fine:

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/cff9da1f-88c6-4d27-b107-4c7b20eedec2" />

I also scrolled through ~140 manga cards with various image sizes and aspect ratios via the Anki Browser's Preview. No issues with any of them displaying outside of the bounds of the vocab section's height.

## Tangent

This tangent is unrelated to the specific problem being addressed here and isn't an issue with the proposed code in this PR. Just noting it down since it came up while I was testing this! Maybe something for a separate issue, if somebody would want to pursue better handling of wide images at some point too.

I noticed there were some cases like this 沸く card:

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/367e97ec-1ae4-4b22-a9a3-a820431dfcd3" />

Where the size of the image could actually be larger than it currently is. But I double-checked and its `max-height` is being set as expected from these changes; it's that way because `max-width` is set to `400px` here:

https://github.com/donkuri/lapis/blob/e0bdeb3fdd87764f99400b7e8719263de5c9c190/src/styling.css#L682-L687

In theory we could increase the `max-width` there to make better use of the space, like to something like `500px` or `600px`:

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/92ff94a2-12c5-464d-99c1-e4853c6be8c8" />

Another example (捧げる) before / after changing that (gets a little tighter):

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/4bc3a519-e91b-45ea-b678-c63693004daf" />

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/ebb90c1f-bb45-4e52-a02f-6ef63484b38a" />

And another example (突拍子もない), where it'd be problematic to do just that:

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/5d0954d6-e954-4a0b-a8dc-ee34e1b563b2" />

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/20d7485b-48a2-449e-a9cb-61241de26370" />

So to avoid the image forcing some text wrapping in cases where it shouldn't that might require additional changes to add a `min-width` to `dh-vocab` (~`250px`, whatever that is in `em` or `rem`? `fit-content` might not be best with flex stuff, not sure), like:

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/d99b69cb-f926-4fde-a7ea-d1c7caaf024c" />

Maybe some `flex` settings adjustment like `flex: 1 1 auto;` for `dh-vocab` / `flex: 0 1 45%;` for `dh-image` to try and prefer the vocab over the image taking up space too?

<img width="1680" height="1336" alt="image" src="https://github.com/user-attachments/assets/a49ffb22-9513-4892-9e66-b674b3952126" />

But then we've looped back around to the original problem (due to that 45% improving wrapping here, but making the image too small again in the other cases). I don't know, I'm not familiar enough with `flex` CSS stuff to know the ideal option of "fit the vocab section without any wrapping, and then make the image as wide as it can be" 😢 Or if it's even possible without JS (using a more complicated resizing logic, that might introduce oscillation).

Seems like it might need some trial and error testing + investigation that is outside of the scope of this issue / PR, so I didn't make any changes around it.