### PR TITLE
Fixed position of audio button on AnkiMobile

### DIFF
--- a/src/styling.css
+++ b/src/styling.css
@@ -51,7 +51,7 @@
 
   --mobile-main-picture-position: "right"; /* "left", "right", "alt" */
   --mobile-sentence-position: "below";
-  --mobile-audio-buttons: "fixed"; /* "fixed", "header", "alt" */
+  --mobile-audio-buttons: "header"; /* "fixed", "header", "alt" */
 
   /* Pitch colors */
   --dark-mode-heiban: #39bae6;

--- a/src/styling.css
+++ b/src/styling.css
@@ -237,6 +237,10 @@ html.mobile {
   text-align: center;
 }
 
+html.mobile #lapis {
+  min-height: -webkit-fill-available;
+}
+
 /* ------- Mobile css ------- */
 @media (max-width: 512px) {
   .images-container {

--- a/src/styling.css
+++ b/src/styling.css
@@ -51,7 +51,7 @@
 
   --mobile-main-picture-position: "right"; /* "left", "right", "alt" */
   --mobile-sentence-position: "below";
-  --mobile-audio-buttons: "header"; /* "fixed", "header", "alt" */
+  --mobile-audio-buttons: "fixed"; /* "fixed", "header", "alt" */
 
   /* Pitch colors */
   --dark-mode-heiban: #39bae6;

--- a/src/styling.css
+++ b/src/styling.css
@@ -237,7 +237,8 @@ html.mobile {
   text-align: center;
 }
 
-html.mobile #lapis {
+html.iphone #lapis,
+html.ipad #lapis {
   min-height: -webkit-fill-available;
 }
 


### PR DESCRIPTION
Minor fix to properly position audio button on AnkiMobile on iPhone. Before/after photos attached. Not sure if "fixed" instead of "header" for --mobile-audio-buttons was a deliberate choice for mobile devices, but this fixes it on iPhone without issues.

Before (audio button in bottom left corner):
![IMG_3036_50](https://github.com/user-attachments/assets/981e2ac3-89ed-4a78-b79b-b1fef7fc9345)

After (button in correct position):
![IMG_3037_50](https://github.com/user-attachments/assets/74ce84b9-4a98-4d19-bda0-5ad2a83124fe)
