### PR TITLE
AnkiMobile add support for User Action on click cards

### DIFF
--- a/src/front.html
+++ b/src/front.html
@@ -69,6 +69,10 @@
       if ((event.key === "c") | (event.key === "C")) toggleContent();
     });
   }
+  var userJs1 = function() {
+    const el = document.getElementById("click");
+    if (el) el.click();
+  };
 
   function HideTargetWord() {
     const targetWords = document.querySelectorAll("#audio b");


### PR DESCRIPTION
Allows in AnkiMobile to use gamepads (controllers)  using User Action 1 to reveal click card sentences.


As configured below, pressing the A button toggles the click cards sentence.
<img width="330" height="666" alt="420AA1DE-4FFE-4555-99C6-04E2CB4EE845" src="https://github.com/user-attachments/assets/cb29490a-c3fa-4d58-a44f-bd833c5bff4a" />

relevant doc: https://docs.ankimobile.net/study-tools.html#study-tools (under User Action 1-8)